### PR TITLE
Update org links

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Clone PeleLMeX
         run: |
           git clone --recursive --shallow-submodules --single-branch \
-            https://github.com/AMReX-Combustion/PeleLMeX.git
+            https://github.com/Pele-Suite/PeleLMeX.git
 
       - name: Point PeleLMeX/Submodules/PelePhysics to this PR
         working-directory: PeleLMeX
@@ -75,7 +75,7 @@ jobs:
       - name: Clone PeleC
         run: |
           git clone --recursive --shallow-submodules --single-branch \
-            https://github.com/AMReX-Combustion/PeleC.git
+            https://github.com/Pele-Suite/PeleC.git
 
       - name: Point PeleC/Submodules/PelePhysics to this PR
         working-directory: PeleC
@@ -128,7 +128,7 @@ jobs:
       - name: Clone PeleLMeX
         run: |
           git clone --recursive --shallow-submodules --single-branch \
-            https://github.com/AMReX-Combustion/PeleLMeX.git
+            https://github.com/Pele-Suite/PeleLMeX.git
 
       - name: Point PeleLMeX/Submodules/PelePhysics to this PR
         working-directory: PeleLMeX
@@ -230,7 +230,7 @@ jobs:
       - name: Clone PeleC
         run: |
           git clone --recursive --shallow-submodules --single-branch \
-            https://github.com/AMReX-Combustion/PeleC
+            https://github.com/Pele-Suite/PeleC
 
       - name: Point PeleC/Submodules/PelePhysics to this PR
         working-directory: PeleC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ to fork *PelePhysics* main repo on your GitHub account, and use a recursive `git
 
 Then step into the *PelePhysics* folder and add the main *PelePhysics* repository as the `upstream` remote in order to keep track of the main repo :
 ~~~
-git add remote upstream https://github.com/AMReX-Combustion/PelePhysics
+git add remote upstream https://github.com/Pele-Suite/PelePhysics
 ~~~
 
 At any point, you can update the `development` branch of your local repository with changes implemented in the main *PelePhysics* repo by pulling from `upstream` :

--- a/Docs/sphinx/Doc_COVO.tex
+++ b/Docs/sphinx/Doc_COVO.tex
@@ -60,9 +60,9 @@
 
 What we will call the \textit{PeleSuite} (see Fig.~\ref{Fig:PeleSuite}) is currently composed of 3 separate codes:
 \begin{itemize}
-\item PelePhysics: (\href{https://github.com/AMReX-Combustion/PelePhysics}{see here}) is a repository of physics databases and implementation code for use within the other Pele codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in PelePhysics. Follow the link to learn more.
+\item PelePhysics: (\href{https://github.com/Pele-Suite/PelePhysics}{see here}) is a repository of physics databases and implementation code for use within the other Pele codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in PelePhysics. Follow the link to learn more.
 \item PeleLM: (\href{https://github.com/AMReX-Combustion/PeleLM}{see here}) is an adaptive-mesh Low-Mach number hydrodynamics code for reacting flows. Note that by the time this short note is written, PeleLM does \textit{not} rely on PelePhysics yet, and uses in place a \textit{ChemDriver} object. Follow the link to learn more.
-\item PeleC: (\href{https://github.com/AMReX-Combustion/PeleC}{see here}) PeleC is an adaptive-mesh compressible hydrodynamics code for reacting flows.
+\item PeleC: (\href{https://github.com/Pele-Suite/PeleC}{see here}) PeleC is an adaptive-mesh compressible hydrodynamics code for reacting flows.
 \end{itemize} 
 All three codes rely on \href{https://amrex-codes.github.io/amrex/}{AMREX}, which is a software frameworks that provides the data structure and enable massive parallelization.
 

--- a/Docs/sphinx/GettingStarted.rst
+++ b/Docs/sphinx/GettingStarted.rst
@@ -6,7 +6,7 @@
 
 Greetings users. As a word of caution, this documentation is in progress. Some parts of the code remain undocumented,
 and some parts of the documentation are out of data. If you are confused by something you read here, or otherwise
-need help with `PelePhysics`, the best course of action is to open a Discussion on the `GitHub page <https://github.com/AMReX-Combustion/PelePhysics/discussions>`_,
+need help with `PelePhysics`, the best course of action is to open a Discussion on the `GitHub page <https://github.com/Pele-Suite/PelePhysics/discussions>`_,
 so the development team and other users can help.
 
 - If you are a complete beginner, I urge you to carefully read the two following chapters :ref:`sec:GetPP` and :ref:`sec:GetCVODE`, to properly set-up your working environment.
@@ -18,7 +18,7 @@ so the development team and other users can help.
 Obtaining `PelePhysics`
 =======================
 
-PelePhysics is primarily intended as a library for use in the other `Pele codes <https://amrex-combustion.github.io>`_, and is automatically downloaded as
+PelePhysics is primarily intended as a library for use in the other `Pele codes <https://Pele-Suite.github.io>`_, and is automatically downloaded as
 a submodule of both PeleC and PeleLMeX. However, it can also be used as a stand-alone solver for chemical reactions and thermodynamic properties,
 or as a library for other codes. Instructions for how to obtain `PelePhysics` for these purposes are provided here.
 
@@ -26,7 +26,7 @@ First, make sure that "Git" is installed on your machine---we recommend version 
 
 1. Clone the `PelePhysics` repository and its submodules: ::
 
-    git clone --recursive https://github.com/AMReX-Combustion/PelePhysics.git
+    git clone --recursive https://github.com/Pele-Suite/PelePhysics.git
 
   This will create a ``PelePhysics`` directory on your machine. The ``--recursive`` option ensures that the required :ref:`sec:GetCVODE` are also downloaded to the
   ``PelePhysics/Submodules`` directory. Set the environment variable ``PELE_PHYSICS_HOME`` to point to the location of this folder (``export PELE_PHYSICS_HOME=$(pwd)/PelePhysics``)

--- a/Docs/sphinx/Introduction.rst
+++ b/Docs/sphinx/Introduction.rst
@@ -11,9 +11,9 @@ Objectives and State-Of-The-Art
 
 What we will call the `PeleSuite` is currently composed of 3 separate codes:
 
-- `PelePhysics <https://github.com/AMReX-Combustion/PelePhysics>`_ is a repository of physics databases and implementation code for use within the other `Pele` codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in `PelePhysics`.
-- `PeleLM <https://github.com/AMReX-Combustion/PeleLM>`_ is an adaptive-mesh Low-Mach number hydrodynamics code for reacting flows. It has a sibling, `PeleLMeX <https://github.com/AMReX-Combustion/PeleLMeX>`_, that solves for the same type of flow using a subtly different numerical approach.
-- `PeleC <https://github.com/AMReX-Combustion/PeleC>`_ is an adaptive-mesh compressible hydrodynamics code for reacting flows.
+- `PelePhysics <https://github.com/Pele-Suite/PelePhysics>`_ is a repository of physics databases and implementation code for use within the other `Pele` codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in `PelePhysics`.
+- `PeleLM <https://github.com/AMReX-Combustion/PeleLM>`_ is an adaptive-mesh Low-Mach number hydrodynamics code for reacting flows. It has a sibling, `PeleLMeX <https://github.com/Pele-Suite/PeleLMeX>`_, that solves for the same type of flow using a subtly different numerical approach.
+- `PeleC <https://github.com/Pele-Suite/PeleC>`_ is an adaptive-mesh compressible hydrodynamics code for reacting flows.
 
 All three codes rely on `AMReX <https://amrex-codes.github.io/amrex>`_, which is a software frameworks that provides the data structure and enable massive parallelization.
 

--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -20,7 +20,7 @@ This section provides relevant notes on using these utilities across the Pele fa
 Premixed Flame Initialization
 =============================
 
-Pre-computed profiles from 1D freely propagating premixed flames are used to initialize a wrinkled `flamesheet <https://amrex-combustion.github.io/PeleLMeX/manual/html/Tutorials_FlameSheet.html>`_ in PeleLMeX, among other problems. Right now, this capability is not used in PeleC, but similar code that accomplishes the same task using data files of the same format is applied in PeleC. The code has two parts, a data container defined in ``PMFData.{H,cpp}`` that loads and stores data from the pre-computed profile, and a function defined in ``PMF.H`` that, when provided this data structure and the bounds of a cell of interest, returns temperature, velocity, and mole fractions from that location.
+Pre-computed profiles from 1D freely propagating premixed flames are used to initialize a wrinkled `flamesheet <https://Pele-Suite.github.io/PeleLMeX/manual/html/Tutorials_FlameSheet.html>`_ in PeleLMeX, among other problems. Right now, this capability is not used in PeleC, but similar code that accomplishes the same task using data files of the same format is applied in PeleC. The code has two parts, a data container defined in ``PMFData.{H,cpp}`` that loads and stores data from the pre-computed profile, and a function defined in ``PMF.H`` that, when provided this data structure and the bounds of a cell of interest, returns temperature, velocity, and mole fractions from that location.
 
 This code has two runtime parameters that may be set in the input file: ::
 

--- a/Docs/sphinx/index.rst
+++ b/Docs/sphinx/index.rst
@@ -7,8 +7,8 @@
 PelePhysics
 ===========
 
-`PelePhysics` is a repository of physics databases and implementation code for use within the other `Pele` codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in `PelePhysics`.  `PelePhysics` has an official project `homepage <https://amrex-combustion.github.io/>`_, and can be obtained via
-`GitHub <https://github.com/AMReX-Combustion/PelePhysics>`_.  The documentation pages appearing here are distributed with the code in the ``Docs/sphinx`` folder as "restructured text" files.
+`PelePhysics` is a repository of physics databases and implementation code for use within the other `Pele` codes. In particular, the choice of chemistry and transport models as well as associated functions and capabilities are managed in `PelePhysics`.  `PelePhysics` has an official project `homepage <https://Pele-Suite.github.io/>`_, and can be obtained via
+`GitHub <https://github.com/Pele-Suite/PelePhysics>`_.  The documentation pages appearing here are distributed with the code in the ``Docs/sphinx`` folder as "restructured text" files.
 The html is built automatically with certain pushes to the `PelePhysics` GibHub repository.  A local version can also be built as follows ::
 
     cd ${PELE_PHYSICS_DIR}/build

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 
 ## Overview
 
-PelePhysics is a repository of physics databases and implementation code for use with the [Pele suite of codes](https://amrex-combustion.github.io),
-primarily the compressible solver [PeleC](https://amrex-combustion.github.io/PeleC/) and low-Mach solver [PeleLMeX](https://amrex-combustion.github.io/PeleLMeX/).
+PelePhysics is a repository of physics databases and implementation code for use with the [Pele suite of codes](https://Pele-Suite.github.io),
+primarily the compressible solver [PeleC](https://Pele-Suite.github.io/PeleC/) and low-Mach solver [PeleLMeX](https://Pele-Suite.github.io/PeleLMeX/).
 
 PelePhysics contains C++ source code for the following physics and other modules, in the `Source` directory:
 
 * *EOS*: Equation of State, include multi-species ideal and real gas options
 * *Transport*: Routines to evaluate multi-species transport properties
 * *Reactions*: Routines for substepped integration of stiff chemical systems, including with CVODE
-* *Spray*: Lagrangian spray droplet library, formerly part of [PeleMP](https://github.com/AMReX-Combustion/PeleMP)
-* *Soot*: An implementation of the Hybrid Method of Moments soot model, formerly part of [PeleMP](https://github.com/AMReX-Combustion/PeleMP)
-* *Radiation*: Radiative heat transfer model based on the spherical harmonics method, formerly [PeleRad](https://github.com/AMReX-Combustion/PeleRad)
+* *Spray*: Lagrangian spray droplet library, formerly part of [PeleMP](https://github.com/Pele-Suite/PeleMP)
+* *Soot*: An implementation of the Hybrid Method of Moments soot model, formerly part of [PeleMP](https://github.com/Pele-Suite/PeleMP)
+* *Radiation*: Radiative heat transfer model based on the spherical harmonics method, formerly [PeleRad](https://github.com/Pele-Suite/PeleRad)
 * *Utility*: Several handy modules for data management across other Pele codes
 
 Additionally, PelePhysics contains a variety of stand-alone tools to aid in Pele simulation workflows, found in the `Support` directory.
@@ -26,7 +26,7 @@ For convenience, the `Mechanisms` directory contains the CEPTR-generated source 
 Cantera and CHEMKIN format data files for each mechanism.
 
 Documentation for these various capabilities, to varying degrees, can be found in the `Docs` directory or online
-at https://amrex-combustion.github.io/PelePhysics/. The papers listed below under the Citation heading may also be valuable resources.
+at https://Pele-Suite.github.io/PelePhysics/. The papers listed below under the Citation heading may also be valuable resources.
 
 PelePhysics has two required dependencies, AMReX and SUNDIALS, which are both git submodules located the `Submodules` directory.
 The `ThirdParty` directory is used when building these submodules, and for downloading and building other optional submodules.
@@ -36,7 +36,7 @@ Finally, the `Testing` directory includes several stand-alone codes for exercisi
 ## Getting Started
 
 PelePhysics is primarily intended as a library for use with other Pele codes. For more information on how to download PelePhysics and
-its dependencies, and how to build the stand-alone test codes, consult the [online documentation](https://amrex-combustion.github.io/PelePhysics/GettingStarted.html).
+its dependencies, and how to build the stand-alone test codes, consult the [online documentation](https://Pele-Suite.github.io/PelePhysics/GettingStarted.html).
 
 ## Acknowledgment
 
@@ -98,14 +98,14 @@ PeleMP and PeleRad, please use the following [Journal of Fluids Engineering arti
 
 A full list of publications documenting the development of the Pele suite and its
 application to various reacting flow and other simulations is available on the main
-[Pele suite page](https://amrex-combustion.github.io/pubs.html). After publication,
+[Pele suite page](https://Pele-Suite.github.io/pubs.html). After publication,
 if you'd like your work to be included on that list, you can request to have it added
-[here](https://github.com/AMReX-Combustion/AMReX-Combustion.github.io/discussions/3).
+[here](https://github.com/Pele-Suite/Pele-Suite.github.io/discussions/3).
 
 ## Getting help
 
-Do you have a question ? Found an issue ? Please use the [GitHub Discussions](https://github.com/AMReX-Combustion/PelePhysics/discussions) to engage
-with the development team or open a new [GitHub issue](https://github.com/AMReX-Combustion/PelePhysics/issues) to report a bug. The development team
+Do you have a question ? Found an issue ? Please use the [GitHub Discussions](https://github.com/Pele-Suite/PelePhysics/discussions) to engage
+with the development team or open a new [GitHub issue](https://github.com/Pele-Suite/PelePhysics/issues) to report a bug. The development team
 also encourages users to take an active role in respectfully answering each other's questions in these spaces. When reporting a bug, it is helpful
 to provide as much detail as possible, including a case description and the major compile and runtime options being used. Though not required,
 it is most effective to create a fork of this repository and share a branch of that fork with a case that minimally reproduces the error.
@@ -115,7 +115,7 @@ New contributions to *PelePhysics* are welcome ! Contributing Guidelines are pro
 ## Versioning
 
 PelePhysics now uses uses a type of semantic versioning to help users navigate different versions of the code,
-which are labeled with [GitHub tags](https://github.com/AMReX-Combustion/PelePhysics/releases/). These tagged versions are not exhaustive, but they adhere to
+which are labeled with [GitHub tags](https://github.com/Pele-Suite/PelePhysics/releases/). These tagged versions are not exhaustive, but they adhere to
 the following convention. Given a version number MAJOR.MINOR.PATCH:
 1. MAJOR version for changes to key aspects of the solver affecting input/source files for all cases, when a key model is changed to significantly affect results of simulations, when a major new capability is added
 2. MINOR version for when a significant feature is added (in a backward compatible manner), accumulation of smaller features, or changes to input file compatibility for less central aspects of the solver (e.g., post-processing) or aspects not affecting all cases
@@ -158,4 +158,4 @@ If the `Pele` codes are built with `Eos_Model = Fuego`, the make system variable
 `PelePhysics` currently supports a cubic EOS model: `Soave-Redlich-Kwong`.  It is built on top of the ideal gas models, and is selected by specifying its name as the `Eos_Model` during the build (the make system requires that both `Eos_Model` and `Chemistry_Model` be specified).  Any additional parameters required for the EOS (e.g., attractions, repulsions, critical states) are either included in the underlying CEPTR database used to generate the source file model implementation, or else are inferred from the input model data.
 
 ### Model generation procedures
-This repository provides the tools necessary for generating new Pele-compatible combustion mechanisms. Please refer to the [CEPTR documentation](https://amrex-combustion.github.io/PelePhysics/Ceptr.html) for instructions on generating mechanism models. Make sure that you edit the `GNUmakefile` where you want to use this (in, e.g., `PeleC/Exec`) so that `Chemistry_Model` is `XXX`.  In `PeleC/Exec/Make.PeleC`, the model is expected to be in the folder `${PELE_PHYSICS_HOME}/Mechanisms/$(Chemistry_Model)`, and it is expected that the folder contains a `Make.package` file to include, so make sure things are where they need to be. Refer to other mechanisms for additional guidance.
+This repository provides the tools necessary for generating new Pele-compatible combustion mechanisms. Please refer to the [CEPTR documentation](https://Pele-Suite.github.io/PelePhysics/Ceptr.html) for instructions on generating mechanism models. Make sure that you edit the `GNUmakefile` where you want to use this (in, e.g., `PeleC/Exec`) so that `Chemistry_Model` is `XXX`.  In `PeleC/Exec/Make.PeleC`, the model is expected to be in the folder `${PELE_PHYSICS_HOME}/Mechanisms/$(Chemistry_Model)`, and it is expected that the folder contains a `Make.package` file to include, so make sure things are where they need to be. Refer to other mechanisms for additional guidance.

--- a/Support/ceptr/README.rst
+++ b/Support/ceptr/README.rst
@@ -2,4 +2,4 @@
  CEPTR: Chemistry Evaluation for Pele Through Recasting
 =======================================================
 
-The documentation for CEPTR can be found at this `link <https://amrex-combustion.github.io/PelePhysics/Ceptr.html>`_.
+The documentation for CEPTR can be found at this `link <https://Pele-Suite.github.io/PelePhysics/Ceptr.html>`_.

--- a/Testing/Regression/README.md
+++ b/Testing/Regression/README.md
@@ -57,7 +57,7 @@ The following example commands will clone the required repositories
     ```
     git clone git@github.com:AMReX-Codes/amrex.git ${REGTEST_SCRATCH}/amrex
     git clone git@github.com:AMReX-Codes/regression_testing ${REGTEST_SCRATCH}/regression_testing
-    git clone git@github.com:AMReX-Combustion/PelePhysics.git ${REGTEST_SCRATCH}/PelePhysics
+    git clone git@github.com:Pele-Suite/PelePhysics.git ${REGTEST_SCRATCH}/PelePhysics
     ```
 
 4.  Move to the location where the tests will be built/run, preferably the 


### PR DESCRIPTION
Change all the references to AMReX-Combustion to Pele-Suite, except for PeleLM, which is still under the AMReX-Combustion organization. Once this is merged, there will be follow up PR's in LMeX and C.