### PR TITLE
TurbInflow: coordinate-based add_turb overload and MESHMAP_V1 HDR trailer

### DIFF
--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -154,12 +154,27 @@ inflow plane data and interpolation approaches for periodic and nonperiodic tang
 Non-uniform and mapped grids
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The inflow data itself is **always uniformly spaced**: the ``HDR`` carries only
-``npts`` and ``probsize`` per direction, and the coordinate-to-index conversion
-in the interpolator is a single affine expression. Turbulence *generated on* a
-stretched or otherwise non-uniform mesh therefore cannot yet be represented in
-the file format, and neither the ``periodic_plt`` nor the ``diag_frame_plane``
-generation mode accounts for a coordinate mapping in the precursor simulation.
+The inflow data is always uniformly spaced *in some coordinate*: the ``HDR``
+carries only ``npts`` and ``probsize`` per direction, and the coordinate-to-index
+conversion in the interpolator is a single affine expression. Which coordinate
+that is depends on how the file was made. Synthetic (``turb_box``) data and data
+extracted from a uniform-mesh precursor are uniform in physical position. Data
+extracted with ``diag_frame_planes`` or ``periodic_plt`` from a precursor that
+ran with a coordinate mapping (for example PeleLMeX's ``geometry.mesh_mapping``)
+is uniform in that run's *computational* (:math:`\xi`) coordinate, because the
+plane files and plotfiles carry the computational geometry with physical
+velocity values.
+
+The ``HDR`` may end with an optional ``MESHMAP_V1`` trailer, placed after the
+plane times so that older readers never see it, describing the precursor's map
+along the two transverse directions (one line each: ``kind p q xi_lo xi_hi``,
+with the same meaning as PeleLMeX's ``MeshMapEvaluator`` payload). A file
+*without* the trailer is, by declaration, uniform in physical position. The
+reader (feature macro ``PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR``) parses the
+trailer and exposes it through ``TurbInflow::file_has_map()``; sampling a file
+that carries one is not yet supported and ``TurbInflow::init()`` aborts rather
+than inject a mis-sampled field. The generators do not yet write the trailer, so
+a file built from a mesh-mapped precursor must not be injected until they do.
 
 A run *consuming* the data may, however, be on a non-uniform grid. The
 turbulence file is indexed by physical position, so a solver whose AMReX grid is

--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -151,6 +151,42 @@ inflow plane data and interpolation approaches for periodic and nonperiodic tang
 .. note:: The TurbInflow capability was not designed with embedded boundaries in mind. It can be applied for simulations using EB, but care should
           be take. Inflows should not be generated from simulations where EBs intersect the inflow plane.
 
+Non-uniform and mapped grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inflow data itself is **always uniformly spaced**: the ``HDR`` carries only
+``npts`` and ``probsize`` per direction, and the coordinate-to-index conversion
+in the interpolator is a single affine expression. Turbulence *generated on* a
+stretched or otherwise non-uniform mesh therefore cannot yet be represented in
+the file format, and neither the ``periodic_plt`` nor the ``diag_frame_plane``
+generation mode accounts for a coordinate mapping in the precursor simulation.
+
+A run *consuming* the data may, however, be on a non-uniform grid. The
+turbulence file is indexed by physical position, so a solver whose AMReX grid is
+a uniform computational grid carrying a coordinate mapping (for example
+PeleLMeX's ``geometry.mesh_mapping``) must not use the ``amrex::Geometry``
+overload of ``TurbInflow::add_turb()``, which would sample the file at
+computational rather than physical coordinates. Such solvers pass the physical
+cell-centre positions of the injection face explicitly, using the overload
+taking ``x_phys`` / ``y_phys`` vectors; the ordering of the two transverse
+directions is given by ``TurbInflow::transverseDirs()``. The presence of that
+overload is advertised by the ``PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB``
+macro.
+
+Whichever entry point is used, the physically meaningful constraint is the ratio
+of the target grid's local spacing on the injection face to the file's spacing.
+``TurbInflow::file_transverse_dx()`` reports the latter in case units (it is also
+printed at ``verbose > 0``) so that a solver can check the ratio: substantially
+above one and the file cannot fill the scales the grid resolves; substantially
+below one and the injected field is aliased onto the grid.
+
+.. note:: Diagnostics that slice the precursor solution -- notably
+          ``DiagFramePlane`` -- locate the requested ``center`` using the AMReX
+          geometry, which for a mapped run is the uniform computational grid.
+          Under a coordinate mapping ``center`` is therefore a *computational*
+          coordinate, not a physical one, and the written plane files carry no
+          mapping metadata.
+
 .. figure:: ./Visualization/TurbInflowData.png
 
 .. _sec_turbforce:

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -6,6 +6,18 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_ParmParse.H>
 
+// Feature macro: this PelePhysics provides the TurbInflow::add_turb()
+// overload that takes the physical positions of the inflow-face cell
+// centres explicitly, rather than deriving them from an amrex::Geometry.
+//
+// A solver whose AMReX grid is a uniform computational (Xi) grid carrying a
+// coordinate mapping -- e.g. PeleLMeX's geometry.mesh_mapping -- cannot use
+// the Geometry-based overload: the turbulence file is indexed by PHYSICAL
+// position, while ProbLo + (i+0.5)*CellSize is the Xi position.  Consumers
+// #ifdef on this macro so that the PelePhysics and solver-side changes can
+// land independently.
+#define PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB 1
+
 namespace pele::physics::turbinflow {
 
 AMREX_ENUM(TurbInterpType, linear, quadratic);
@@ -75,6 +87,9 @@ public:
 
   void init(amrex::Geometry const& geom);
 
+  //! Uniform-grid entry point: the physical position of a cell centre is
+  //! ProbLo + (i+0.5)*CellSize.  Builds those coordinates and forwards to
+  //! the overload below, which holds the single implementation.
   void add_turb(
     amrex::Box const& bx,
     amrex::FArrayBox& data,
@@ -83,6 +98,65 @@ public:
     const amrex::Real time,
     const int dir,
     const amrex::Orientation::Side& side);
+
+  /**
+   * \brief Add turbulence to \p bx using caller-supplied physical
+   *        coordinates for the two transverse directions.
+   *
+   * For a solver on a non-uniform or mapped grid this is the correct entry
+   * point: the turbulence file is sampled by physical position, which the
+   * caller (who owns the mapping) is the only one able to compute.
+   *
+   * \p x_phys and \p y_phys are the physical cell-centre coordinates along
+   * the transverse directions \c tdir1 and \c tdir2 given by
+   * transverseDirs(dir, ...), indexed from \c bx.smallEnd(tdir1) and
+   * \c bx.smallEnd(tdir2) respectively, and must span the corresponding
+   * extents of \p bx.  They are in case units; the per-TurbParm
+   * \c turb_scale_loc is applied internally, exactly as for the
+   * Geometry-based overload.
+   *
+   * \p domain is the (Xi-space) problem domain Box, used only to locate the
+   * ghost plane being filled.
+   */
+  void add_turb(
+    amrex::Box const& bx,
+    amrex::FArrayBox& data,
+    const int dcomp,
+    amrex::Box const& domain,
+    const amrex::Vector<amrex::Real>& x_phys,
+    const amrex::Vector<amrex::Real>& y_phys,
+    const amrex::Real time,
+    const int dir,
+    const amrex::Orientation::Side& side);
+
+  /**
+   * \brief The two transverse directions associated with injection
+   *        direction \p dir, in the order the turbulence data uses them.
+   *
+   * Exposed so that callers building coordinate vectors for the overload
+   * above cannot disagree with the internal convention.
+   */
+  static AMREX_FORCE_INLINE void
+  transverseDirs(const int dir, int& tdir1, int& tdir2) noexcept
+  {
+    tdir1 = (dir != 0) ? 0 : 1;
+    tdir2 = (dir != 0) ? ((dir == 2) ? 1 : 2) : 2;
+  }
+
+  /**
+   * \brief Transverse cell spacings of the turbulence file feeding the
+   *        (\p dir, \p side) face, expressed in case units.
+   *
+   * Returns false when no turb file acts on that face.  Intended for
+   * resolution-consistency diagnostics: the ratio of the target grid's
+   * local spacing to this value is what decides whether the injected
+   * field can fill the grid's resolved scales.
+   */
+  bool file_transverse_dx(
+    const int dir,
+    const amrex::Orientation::Side& side,
+    amrex::Real& dx_tdir1,
+    amrex::Real& dx_tdir2) const;
 
   bool is_initialized() const { return turbinflow_initialized; }
 

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -18,6 +18,12 @@
 // land independently.
 #define PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB 1
 
+// Feature macro: the HDR reader understands the optional MESHMAP_V1 trailer
+// that tags a turbulence file as uniform in a precursor's computational (Xi)
+// coordinate rather than in physical position.  Files without the trailer
+// are, by declaration, uniform in physical position.
+#define PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR 1
+
 namespace pele::physics::turbinflow {
 
 AMREX_ENUM(TurbInterpType, linear, quadratic);
@@ -76,6 +82,20 @@ struct TurbParm
 
   amrex::Vector<long> offset;
   int kmax; // Number of plane in Turbfile
+
+  // Optional coordinate-mapping descriptor of the turbulence file, read
+  // from the MESHMAP_V1 trailer of HDR (see the file-format notes in
+  // turbinflow.cpp).  When present, the file's transverse grid is uniform
+  // in the *computational* (Xi) coordinate of the precursor that produced
+  // it, and a physical position must be inverted through this map before
+  // being turned into a file index.  Absent trailer => has_map == false and
+  // the file is uniform in physical position.
+  bool has_map = false;
+  amrex::GpuArray<int, 2> map_kind = {{0, 0}};
+  amrex::GpuArray<amrex::Real, 2> map_p = {{0.0, 0.0}};
+  amrex::GpuArray<int, 2> map_q = {{-1, -1}};
+  amrex::GpuArray<amrex::Real, 2> map_xi_lo = {{0.0, 0.0}};
+  amrex::GpuArray<amrex::Real, 2> map_xi_hi = {{0.0, 0.0}};
 };
 
 struct TurbInflow
@@ -157,6 +177,15 @@ public:
     const amrex::Orientation::Side& side,
     amrex::Real& dx_tdir1,
     amrex::Real& dx_tdir2) const;
+
+  /**
+   * \brief Whether the turbulence file feeding the (\p dir, \p side) face
+   *        carries a MESHMAP_V1 trailer, i.e. is uniform in a precursor's
+   *        computational coordinate rather than in physical position.
+   *
+   * Returns false when no turb file acts on that face.
+   */
+  bool file_has_map(const int dir, const amrex::Orientation::Side& side) const;
 
   bool is_initialized() const { return turbinflow_initialized; }
 

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -129,9 +129,10 @@ public:
    *
    * \p x_phys and \p y_phys are the physical cell-centre coordinates along
    * the transverse directions \c tdir1 and \c tdir2 given by
-   * transverseDirs(dir, ...), indexed from \c bx.smallEnd(tdir1) and
-   * \c bx.smallEnd(tdir2) respectively, and must span the corresponding
-   * extents of \p bx.  They are in case units; the per-TurbParm
+   * transverseDirs(dir, ...). They must have lengths bx.length(tdir1) and
+   * bx.length(tdir2), with x_phys[0] corresponding to index
+   * bx.smallEnd(tdir1) (and similarly for y_phys/tdir2), and must span the
+   * corresponding extents of \p bx.  They are in case units; the per-TurbParm
    * \c turb_scale_loc is applied internally, exactly as for the
    * Geometry-based overload.
    *

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -124,6 +124,10 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         , tp[n].pboxlo[2] = 0.0;)
 
       if (tp[n].verbose > 0) {
+        if (tp[n].turb_scale_loc == 0.0) {
+          amrex::Abort(
+            "TurbInflow::init(): turb_scale_loc must be non-zero for " + tp_list[n]);
+        }
         // The file is uniformly spaced by construction (the HDR carries only
         // npts and probsize).  Report the equivalent spacing in case units so
         // that it can be compared against the target grid's spacing on the
@@ -184,7 +188,7 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
             tp[n].map_q[idim] >> tp[n].map_xi_lo[idim] >> tp[n].map_xi_hi[idim];
         }
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-          is.good() || is.eof(),
+          is.good(),
           "TurbInflow::init(): malformed MESHMAP_V1 trailer in " + turb_header);
         tp[n].has_map = true;
         if (tp[n].verbose > 0) {
@@ -218,12 +222,15 @@ bool
 TurbInflow::file_has_map(
   const int dir, const amrex::Orientation::Side& side) const
 {
+  bool found = false;
+  bool any_has_map = false;
   for (const auto& tpn : tp) {
     if (tpn.dir == dir && tpn.side == side) {
-      return tpn.has_map;
+      found = true;
+      any_has_map = any_has_map || tpn.has_map;
     }
   }
-  return false;
+  return found ? any_has_map : false;
 }
 
 bool

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -181,13 +181,11 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
       if ((is >> token) && token == "MESHMAP_V1") {
         for (int idim = 0; idim < 2; ++idim) {
           is >> tp[n].map_kind[idim] >> tp[n].map_p[idim] >>
-            tp[n].map_q[idim] >> tp[n].map_xi_lo[idim] >>
-            tp[n].map_xi_hi[idim];
+            tp[n].map_q[idim] >> tp[n].map_xi_lo[idim] >> tp[n].map_xi_hi[idim];
         }
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
           is.good() || is.eof(),
-          "TurbInflow::init(): malformed MESHMAP_V1 trailer in " +
-            turb_header);
+          "TurbInflow::init(): malformed MESHMAP_V1 trailer in " + turb_header);
         tp[n].has_map = true;
         if (tp[n].verbose > 0) {
           amrex::Print() << "   " << tp_list[n]

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -126,7 +126,8 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
       if (tp[n].verbose > 0) {
         if (tp[n].turb_scale_loc == 0.0) {
           amrex::Abort(
-            "TurbInflow::init(): turb_scale_loc must be non-zero for " + tp_list[n]);
+            "TurbInflow::init(): turb_scale_loc must be non-zero for " +
+            tp_list[n]);
         }
         // The file is uniformly spaced by construction (the HDR carries only
         // npts and probsize).  Report the equivalent spacing in case units so

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -161,10 +161,71 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
           is >> tp[n].planeTimes[i]; // Time for each plane
         }
       }
+
+      // Optional trailer.  Everything a legacy reader consumes ends with the
+      // plane times, so anything appended after them is invisible to older
+      // code and a file without it is, by declaration, uniform in physical
+      // position.  Format (one line per transverse direction, in the file's
+      // own transverse order):
+      //
+      //   MESHMAP_V1
+      //   <kind> <p> <q> <xi_lo> <xi_hi>
+      //   <kind> <p> <q> <xi_lo> <xi_hi>
+      //
+      // kind/p/q follow PeleLMeX's MeshMapEvaluator (0 identity, 1 constant,
+      // 2 exp stretch, 3 tanh stretch); xi_lo/xi_hi are the precursor's
+      // computational-domain bounds along that axis, which the inverse map
+      // needs.  A trailer marks the file as uniform in the precursor's Xi
+      // coordinate rather than in physical position.
+      std::string token;
+      if ((is >> token) && token == "MESHMAP_V1") {
+        for (int idim = 0; idim < 2; ++idim) {
+          is >> tp[n].map_kind[idim] >> tp[n].map_p[idim] >>
+            tp[n].map_q[idim] >> tp[n].map_xi_lo[idim] >>
+            tp[n].map_xi_hi[idim];
+        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+          is.good() || is.eof(),
+          "TurbInflow::init(): malformed MESHMAP_V1 trailer in " +
+            turb_header);
+        tp[n].has_map = true;
+        if (tp[n].verbose > 0) {
+          amrex::Print() << "   " << tp_list[n]
+                         << " carries a MESHMAP_V1 trailer: file is uniform "
+                            "in the precursor's Xi coordinate (kinds "
+                         << tp[n].map_kind[0] << ", " << tp[n].map_kind[1]
+                         << ")\n";
+        }
+        // The sampling path below converts case positions to file indices
+        // with a single affine expression, i.e. it assumes the file is
+        // uniform in physical position.  Until it can invert the file's map
+        // (next step of the stretched-mesh work), refuse rather than inject
+        // a silently mis-sampled field.
+        amrex::Abort(
+          "TurbInflow::init(): turbulence file " + tp[n].m_turb_file +
+          " was generated on a mesh-mapped precursor (MESHMAP_V1 trailer). "
+          "Sampling such a file is not yet supported by this TurbInflow.");
+      } else if (!token.empty() && !is.eof()) {
+        amrex::Print() << "TurbInflow: WARNING ignoring unrecognised trailing "
+                          "content in "
+                       << turb_header << " starting at '" << token << "'\n";
+      }
       is.close();
     }
     turbinflow_initialized = true;
   }
+}
+
+bool
+TurbInflow::file_has_map(
+  const int dir, const amrex::Orientation::Side& side) const
+{
+  for (const auto& tpn : tp) {
+    if (tpn.dir == dir && tpn.side == side) {
+      return tpn.has_map;
+    }
+  }
+  return false;
 }
 
 bool

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -123,6 +123,17 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         , tp[n].pboxlo[1] = turb_center[1] - 0.5 * tp[n].pboxsize[1];
         , tp[n].pboxlo[2] = 0.0;)
 
+      if (tp[n].verbose > 0) {
+        // The file is uniformly spaced by construction (the HDR carries only
+        // npts and probsize).  Report the equivalent spacing in case units so
+        // that it can be compared against the target grid's spacing on the
+        // injection face -- see PeleLMeX's turbInflow resolution check.
+        amrex::Print() << "   transverse spacing of " << tp_list[n]
+                       << " in case units: "
+                       << tp[n].dx[0] / tp[n].turb_scale_loc << " x "
+                       << tp[n].dx[1] / tp[n].turb_scale_loc << "\n";
+      }
+
       // Swirl type: we can't load more planes than are available
       if (tp[n].istimeplanes) {
         tp[n].nplane = AMREX_D_PICK(
@@ -156,6 +167,26 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
   }
 }
 
+bool
+TurbInflow::file_transverse_dx(
+  const int dir,
+  const amrex::Orientation::Side& side,
+  amrex::Real& dx_tdir1,
+  amrex::Real& dx_tdir2) const
+{
+  for (const auto& tpn : tp) {
+    if (tpn.dir == dir && tpn.side == side) {
+      // tp.dx lives in turb-file units; queried coordinates are multiplied
+      // by turb_scale_loc before the lookup, so the equivalent spacing in
+      // case units is dx / turb_scale_loc.
+      dx_tdir1 = tpn.dx[0] / tpn.turb_scale_loc;
+      dx_tdir2 = tpn.dx[1] / tpn.turb_scale_loc;
+      return true;
+    }
+  }
+  return false;
+}
+
 void
 TurbInflow::add_turb(
   amrex::Box const& bx,
@@ -168,18 +199,61 @@ TurbInflow::add_turb(
 {
   AMREX_ALWAYS_ASSERT(turbinflow_initialized);
 
+  // Uniform grid: cell-centre positions are affine in the index.  Build
+  // them and defer to the coordinate-based overload so that there is only
+  // one copy of the interpolation logic.
+  int tdir1 = 0;
+  int tdir2 = 0;
+  transverseDirs(dir, tdir1, tdir2);
+
+  amrex::Vector<amrex::Real> x(bx.length(tdir1));
+  amrex::Vector<amrex::Real> y(bx.length(tdir2));
+  for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+    const int idx = bx.smallEnd(tdir1) + i;
+    x[i] = geom.ProbLo()[tdir1] +
+           (static_cast<amrex::Real>(idx) + 0.5) * geom.CellSize(tdir1);
+  }
+  for (int j = 0; j < static_cast<int>(y.size()); ++j) {
+    const int idx = bx.smallEnd(tdir2) + j;
+    y[j] = geom.ProbLo()[tdir2] +
+           (static_cast<amrex::Real>(idx) + 0.5) * geom.CellSize(tdir2);
+  }
+
+  add_turb(bx, data, dcomp, geom.Domain(), x, y, time, dir, side);
+}
+
+void
+TurbInflow::add_turb(
+  amrex::Box const& bx,
+  amrex::FArrayBox& data,
+  const int dcomp,
+  amrex::Box const& domain,
+  const amrex::Vector<amrex::Real>& x_phys,
+  const amrex::Vector<amrex::Real>& y_phys,
+  const amrex::Real time,
+  const int dir,
+  const amrex::Orientation::Side& side)
+{
+  AMREX_ALWAYS_ASSERT(turbinflow_initialized);
+
   // Box on which we will access data
   amrex::Box bvalsBox = bx;
   int planeLoc =
-    (side == amrex::Orientation::low ? geom.Domain().smallEnd()[dir] - 1
-                                     : geom.Domain().bigEnd()[dir] + 1);
+    (side == amrex::Orientation::low ? domain.smallEnd()[dir] - 1
+                                     : domain.bigEnd()[dir] + 1);
   bvalsBox.setSmall(dir, planeLoc);
   bvalsBox.setBig(dir, planeLoc);
 
   // Define box that we will fill with turb: need to be z-normal
   // Get transverse directions
-  int tdir1 = (dir != 0) ? 0 : 1;
-  int tdir2 = (dir != 0) ? ((dir == 2) ? 1 : 2) : 2;
+  int tdir1 = 0;
+  int tdir2 = 0;
+  transverseDirs(dir, tdir1, tdir2);
+  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    static_cast<int>(x_phys.size()) == bvalsBox.length(tdir1) &&
+      static_cast<int>(y_phys.size()) == bvalsBox.length(tdir2),
+    "TurbInflow::add_turb(): supplied coordinate vectors must span the "
+    "transverse extents of bx");
   int tr1Lo = bvalsBox.smallEnd()[tdir1];
   int tr1Hi = bvalsBox.bigEnd()[tdir1];
   int tr2Lo = bvalsBox.smallEnd()[tdir2];
@@ -195,17 +269,15 @@ TurbInflow::add_turb(
 
     if (tpn.dir == dir && tpn.side == side) {
 
-      // 0 and 1 are the two transverse directions
+      // 0 and 1 are the two transverse directions.  turb_scale_loc is a
+      // per-TurbParm quantity, so the scaling is applied here rather than
+      // once by the caller.
       amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);
-      for (int i = turbBox.smallEnd()[0]; i <= turbBox.bigEnd()[0]; ++i) {
-        x[i - turbBox.smallEnd()[0]] =
-          (geom.ProbLo()[tdir1] + (i + 0.5) * geom.CellSize(tdir1)) *
-          tpn.turb_scale_loc;
+      for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+        x[i] = x_phys[i] * tpn.turb_scale_loc;
       }
-      for (int j = turbBox.smallEnd()[1]; j <= turbBox.bigEnd()[1]; ++j) {
-        y[j - turbBox.smallEnd()[1]] =
-          (geom.ProbLo()[tdir2] + (j + 0.5) * geom.CellSize(tdir2)) *
-          tpn.turb_scale_loc;
+      for (int j = 0; j < static_cast<int>(y.size()); ++j) {
+        y[j] = y_phys[j] * tpn.turb_scale_loc;
       }
 
       // Get the turbulence


### PR DESCRIPTION
This PR adds some guards and prepares for a follow-up PR in PeleLMeX that will be expecting the changes here. The work is related to mesh stretching and the turbulence and recycling boundary conditions.

Every existing PeleC and PeleLMeX case behaves identically; existing turb files that carry no mesh-mapping trailer text read exactly as before; a file with the new trailer (no generator writes one yet) is refused at init(); the two feature macros PeleLMeX commits for this capability land independently.  
