### PR TITLE
TurbInflow: sample turbulence files generated on mesh-mapped precursors

### DIFF
--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -165,42 +165,75 @@ is uniform in that run's *computational* (:math:`\xi`) coordinate, because the
 plane files and plotfiles carry the computational geometry with physical
 velocity values.
 
-The ``HDR`` may end with an optional ``MESHMAP_V1`` trailer, placed after the
-plane times so that older readers never see it, describing the precursor's map
-along the two transverse directions (one line each: ``kind p q xi_lo xi_hi``,
-with the same meaning as PeleLMeX's ``MeshMapEvaluator`` payload). A file
-*without* the trailer is, by declaration, uniform in physical position. The
-reader (feature macro ``PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR``) parses the
-trailer and exposes it through ``TurbInflow::file_has_map()``; sampling a file
-that carries one is not yet supported and ``TurbInflow::init()`` aborts rather
-than inject a mis-sampled field. The generators do not yet write the trailer, so
-a file built from a mesh-mapped precursor must not be injected until they do.
+Such a file is tagged by an optional ``MESHMAP_V2`` trailer at the end of the
+``HDR``, placed after everything a legacy reader consumes (the plane times, or
+the plane offsets when there are no times) so that older readers never see it.
+It has one line per transverse direction, in the file's own transverse order::
 
-A run *consuming* the data may, however, be on a non-uniform grid. The
-turbulence file is indexed by physical position, so a solver whose AMReX grid is
-a uniform computational grid carrying a coordinate mapping (for example
-PeleLMeX's ``geometry.mesh_mapping``) must not use the ``amrex::Geometry``
-overload of ``TurbInflow::add_turb()``, which would sample the file at
-computational rather than physical coordinates. Such solvers pass the physical
-cell-centre positions of the injection face explicitly, using the overload
-taking ``x_phys`` / ``y_phys`` vectors; the ordering of the two transverse
-directions is given by ``TurbInflow::transverseDirs()``. The presence of that
-overload is advertised by the ``PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB``
+  MESHMAP_V2
+  <kind> <p> <p2> <p3> <q> <xi_lo> <xi_hi>
+  <kind> <p> <p2> <p3> <q> <xi_lo> <xi_hi>
+
+``kind``/``p``/``p2``/``p3``/``q`` are the per-axis payload of
+``pele::physics::MeshMapEvaluator`` (``Source/Utility/MeshMap``, the same
+descriptor PeleLMeX uses for its mapping: 0 identity, 1 constant, 2 exponential
+stretch, 3 tanh stretch, 4 interior stretch), and ``xi_lo``/``xi_hi`` are the
+precursor's computational-domain bounds along that axis. The generators write
+the trailer when their input carries the precursor's ``geometry.mesh_mapping``
+block (copy those lines verbatim; see ``Support/TurbInflowGenerator/README.md``),
+and write nothing otherwise. A file *without* the trailer is, by declaration,
+uniform in physical position. (An earlier ``MESHMAP_V1`` form, ``kind p q xi_lo
+xi_hi``, is still read.)
+
+``TurbInflow`` handles both kinds of file with one rule: the physical position
+of each target cell is converted to the file's own coordinate, and the
+interpolation then proceeds unchanged. For a physically-uniform file the
+conversion is the identity; for a mapped file it is the inverse of the file's
+map, so the interpolation happens in the precursor's :math:`\xi`. This is the
+standard mapped-grid argument -- for a smooth map the interpolant's error is
+the same order in :math:`\Delta\xi` as it would be in :math:`\Delta x` -- and it
+covers every combination of uniform or mapped file and uniform or mapped target.
+When the target's map and computational grid coincide with the file's, the
+conversion lands on file cell centres and the file is reproduced exactly (the
+same-grid guarantee above, now also for mapped meshes). With ``tile_periodic``
+the position is wrapped into the file's physical period before the inverse.
+
+For a mapped file ``turb_center`` is optional: by default the file is placed
+where the precursor had it. If given, it is in the file's :math:`\xi` units,
+must lie within ``[xi_lo, xi_hi]``, and the equivalent physical position is
+printed. The availability of this sampling support is advertised by the
+``PELEPHYSICS_TURBINFLOW_SAMPLES_MESHMAP`` macro (the trailer reader alone by
+``PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR``); ``TurbInflow::file_has_map()``
+and ``file_map()`` expose the file's descriptor so a solver can report whether
+its own map matches.
+
+A run *consuming* the data may itself be on a non-uniform grid. The turbulence
+file is indexed by physical position, so a solver whose AMReX grid is a uniform
+computational grid carrying a coordinate mapping must not use the
+``amrex::Geometry`` overload of ``TurbInflow::add_turb()``, which would sample
+the file at computational rather than physical coordinates. Such solvers pass
+the physical cell-centre positions of the injection face explicitly, using the
+overload taking ``x_phys`` / ``y_phys`` vectors; the ordering of the two
+transverse directions is given by ``TurbInflow::transverseDirs()``. The presence
+of that overload is advertised by the ``PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB``
 macro.
 
 Whichever entry point is used, the physically meaningful constraint is the ratio
 of the target grid's local spacing on the injection face to the file's spacing.
-``TurbInflow::file_transverse_dx()`` reports the latter in case units (it is also
-printed at ``verbose > 0``) so that a solver can check the ratio: substantially
-above one and the file cannot fill the scales the grid resolves; substantially
-below one and the injected field is aliased onto the grid.
+``TurbInflow::file_transverse_dx()`` reports the latter in case units (the mean
+for a mapped file, whose physical spacing varies; ``file_transverse_dx_range()``
+gives its extremes; both are also printed at ``verbose > 0``) so that a solver
+can check the ratio: substantially above one and the file cannot fill the scales
+the grid resolves; substantially below one and the injected field is aliased
+onto the grid.
 
 .. note:: Diagnostics that slice the precursor solution -- notably
           ``DiagFramePlane`` -- locate the requested ``center`` using the AMReX
           geometry, which for a mapped run is the uniform computational grid.
           Under a coordinate mapping ``center`` is therefore a *computational*
           coordinate, not a physical one, and the written plane files carry no
-          mapping metadata.
+          mapping metadata; the mapping enters only through the generator's
+          input, as described above.
 
 .. figure:: ./Visualization/TurbInflowData.png
 

--- a/Source/Utility/MeshMap/Make.package
+++ b/Source/Utility/MeshMap/Make.package
@@ -1,0 +1,4 @@
+CEXE_headers += MeshMapEvaluator.H MeshMapEvaluatorInputs.H
+
+VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/MeshMap
+INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/MeshMap

--- a/Source/Utility/MeshMap/MeshMapEvaluator.H
+++ b/Source/Utility/MeshMap/MeshMapEvaluator.H
@@ -583,7 +583,7 @@ struct MeshMapEvaluator
   }
 
   /// Clamp a normalized coordinate into [0,1].  Public on purpose: device
-  /// code may need it and GPU builds have tripped over private statics.
+  /// code may need it and GPU builds have tripped over private statics. # codespell:ignore=statics
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
   clamp01(amrex::Real v) noexcept
   {

--- a/Source/Utility/MeshMap/MeshMapEvaluator.H
+++ b/Source/Utility/MeshMap/MeshMapEvaluator.H
@@ -1,0 +1,596 @@
+#ifndef PELE_PHYSICS_MESHMAP_EVALUATOR_H
+#define PELE_PHYSICS_MESHMAP_EVALUATOR_H
+
+#include <AMReX.H>
+#include <AMReX_Algorithm.H>
+#include <AMReX_BLassert.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+#include <AMReX_SPACE.H>
+
+#include <cmath>
+#include <limits>
+
+namespace pele::physics {
+
+/**
+ * \brief Device-callable physical-coordinate evaluator for a
+ *        single-block, diagonal, axis-aligned mesh mapping
+ *        \f$X = \Phi(\xi)\f$ laid over AMReX's uniform Xi-space grid.
+ *
+ * Originally PeleLMeX's \c MeshMapEvaluator (its \c geometry.mesh_mapping
+ * subsystem builds the metric MultiFabs from the primitives below); it
+ * lives in PelePhysics so that utilities which must agree with the solver
+ * on the mapping -- the turbulent-inflow reader, the inflow-file
+ * generators -- share one definition instead of re-deriving it.  PeleLMeX
+ * aliases this type.
+ *
+ * It is a trivially-copyable POD: an enum tag identifying which
+ * concrete mapping is active plus a small fixed-size payload of
+ * per-axis parameters.  The solver's host-side factory (PeleLMeX's
+ * \c MeshMap::make_evaluator()) or \c make_evaluator_from_inputs() in
+ * \c MeshMapEvaluatorInputs.H returns a populated instance, which is
+ * passed by value into device lambdas.  No virtual dispatch, no MultiFab
+ * lookups per call.
+ *
+ * When no mesh mapping is active the evaluator defaults to
+ * \c Kind::Identity and \c x_phys_cc / \c x_phys_face return the
+ * unmapped \f$\xi\f$-space coordinate, i.e. the formula
+ * \f$x = \text{prob\_lo} + (\text{idx}+0.5)\,\Delta x\f$.
+ */
+struct MeshMapEvaluator
+{
+  enum class Kind : int {
+    Identity = 0,
+    Constant = 1,
+    ExpStretch = 2,
+    TanhStretch = 3,
+    InteriorStretch = 4
+  };
+
+  // Below this magnitude all stretching parameters revert to the
+  // identity mapping (keeps the formulas numerically well-defined as
+  // beta -> 0).
+  static constexpr amrex::Real BETA_EPS = amrex::Real(1.0e-8);
+
+  /// Mapping kind currently active.
+  Kind m_kind{Kind::Identity};
+
+  /// Per-axis primary parameter.  Meaning depends on \c m_kind:
+  ///   Identity        : unused
+  ///   Constant        : per-axis stretch factor
+  ///   ExpStretch      : beta on the stretched axis, 0 elsewhere
+  ///   TanhStretch     : per-axis beta (length-preserving)
+  ///   InteriorStretch : per-axis beta_lo (coarsening rate towards prob_lo)
+  amrex::Real m_p[AMREX_SPACEDIM] = {AMREX_D_DECL(0.0, 0.0, 0.0)};
+
+  /// Per-axis secondary Real parameter.  Meaning depends on \c m_kind:
+  ///   InteriorStretch : per-axis beta_hi (coarsening rate towards prob_hi)
+  ///   others          : unused (0)
+  amrex::Real m_p2[AMREX_SPACEDIM] = {AMREX_D_DECL(0.0, 0.0, 0.0)};
+
+  /// Per-axis tertiary Real parameter.  Meaning depends on \c m_kind:
+  ///   InteriorStretch : per-axis Xi-space split s_c in (0,1), i.e. the
+  ///                     fraction of the cells placed below the clustering
+  ///                     point.  Everything else about the map follows from
+  ///                     (beta_lo, beta_hi, s_c) in closed form.
+  ///   others          : unused (0)
+  amrex::Real m_p3[AMREX_SPACEDIM] = {AMREX_D_DECL(0.0, 0.0, 0.0)};
+
+  /// Per-axis discrete parameter.  Meaning depends on \c m_kind:
+  ///   ExpStretch  : 0 = wall at lo end, 1 = wall at hi end,
+  ///                 -1 if this axis is not the stretched one
+  ///   others      : unused (-1)
+  int m_q[AMREX_SPACEDIM] = {AMREX_D_DECL(-1, -1, -1)};
+
+  // ======================================================================
+  //  Mapping primitives --- the single source of truth
+  // ======================================================================
+  //
+  // Every concrete map's create_map() and fill_nodal_displacement(), and
+  // every case of x_phys_from_xi() below, are expressed in terms of these.
+  // They live here, in one place, precisely so that the metric a map writes
+  // into its MultiFabs cannot drift away from the coordinate this evaluator
+  // reports for the same point: for each family, *_fac is by construction
+  // the derivative of *_offset_norm.
+  //
+  // Convention throughout: `s` is the Xi-space fraction of the axis,
+  //     s = (xi - prob_lo) / L,  s in [0,1],
+  // and *_offset_norm returns the physical fraction (x_phys - prob_lo)/L,
+  // so that x_phys = prob_lo + L * offset_norm(s, ...).  All are
+  // device-callable and well behaved as beta -> 0, where they reduce to
+  // fac = 1 and offset_norm(s) = s (the identity map).
+
+  // ---- ExpStretchMap primitives (one-sided exponential) ----------------
+
+  /**
+   * \brief \f$\mathrm{fac} = \beta e^{\beta\eta}/(e^\beta - 1)\f$, where
+   *        \f$\eta\f$ measures distance from the wall end.
+   *
+   * \p wall_end is 0 for a wall at \c prob_lo, 1 for a wall at \c prob_hi
+   * (the mirrored case).
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  exp_fac(amrex::Real s, amrex::Real beta, int wall_end) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return amrex::Real(1.0);
+    }
+    const amrex::Real eta = (wall_end == 1) ? (amrex::Real(1.0) - s) : s;
+    return beta * std::exp(beta * eta) / (std::exp(beta) - amrex::Real(1.0));
+  }
+
+  /**
+   * \brief \f$(x_{\mathrm{phys}} - x_{\mathrm{lo}})/L\f$ for the
+   *        one-sided exponential map; the integral of \c exp_fac.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  exp_offset_norm(amrex::Real s, amrex::Real beta, int wall_end) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return s;
+    }
+    const amrex::Real eta = (wall_end == 1) ? (amrex::Real(1.0) - s) : s;
+    const amrex::Real off = (std::exp(beta * eta) - amrex::Real(1.0)) /
+                            (std::exp(beta) - amrex::Real(1.0));
+    return (wall_end == 1) ? (amrex::Real(1.0) - off) : off;
+  }
+
+  /**
+   * \brief Inverse of \c exp_offset_norm: the Xi-space fraction \f$s\f$ at
+   *        which the physical fraction \p off is reached.
+   *
+   * Closed form (\c log).  \p off must lie in [0,1]; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  exp_offset_inv(amrex::Real off, amrex::Real beta, int wall_end) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return off;
+    }
+    if (wall_end == 1) {
+      off = amrex::Real(1.0) - off;
+    }
+    const amrex::Real den = std::exp(beta) - amrex::Real(1.0);
+    const amrex::Real eta = std::log(off * den + amrex::Real(1.0)) / beta;
+    return (wall_end == 1) ? (amrex::Real(1.0) - eta) : eta;
+  }
+
+  // ---- TanhStretchMap primitives (two-sided, clusters at both ends) ----
+
+  /**
+   * \brief \f$\mathrm{fac} = \beta\,\mathrm{sech}^2(\beta(2s-1))/
+   *        \tanh\beta\f$.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  tanh_fac(amrex::Real s, amrex::Real beta) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return amrex::Real(1.0);
+    }
+    const amrex::Real sech =
+      amrex::Real(1.0) /
+      std::cosh(beta * (amrex::Real(2.0) * s - amrex::Real(1.0)));
+    return beta * sech * sech / std::tanh(beta);
+  }
+
+  /**
+   * \brief \f$(x_{\mathrm{phys}} - x_{\mathrm{lo}})/L\f$ for the two-sided
+   *        \c tanh map; the integral of \c tanh_fac.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  tanh_offset_norm(amrex::Real s, amrex::Real beta) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return s;
+    }
+    return amrex::Real(0.5) *
+           (amrex::Real(1.0) +
+            std::tanh(beta * (amrex::Real(2.0) * s - amrex::Real(1.0))) /
+              std::tanh(beta));
+  }
+
+  /**
+   * \brief Inverse of \c tanh_offset_norm: the Xi-space fraction \f$s\f$ at
+   *        which the physical fraction \p off is reached.
+   *
+   * Closed form (\c atanh).  \p off in [0,1] puts the argument in
+   * [-tanh(beta), tanh(beta)], strictly inside atanh's domain for any finite
+   * beta; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  tanh_offset_inv(amrex::Real off, amrex::Real beta) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return off;
+    }
+    const amrex::Real arg =
+      (amrex::Real(2.0) * off - amrex::Real(1.0)) * std::tanh(beta);
+    return amrex::Real(0.5) * (amrex::Real(1.0) + std::atanh(arg) / beta);
+  }
+
+  // ---- InteriorStretchMap primitives -----------------------------------
+
+  /** \brief \f$\sinh(z)/z\f$, accurate (and finite) as \f$z\to 0\f$. */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_sinhc(amrex::Real z) noexcept
+  {
+    const amrex::Real z2 = z * z;
+    if (z2 < amrex::Real(1.0e-8)) {
+      return amrex::Real(1.0) +
+             z2 * (amrex::Real(1.0) / amrex::Real(6.0) +
+                   z2 * (amrex::Real(1.0) / amrex::Real(120.0)));
+    }
+    return std::sinh(z) / z;
+  }
+
+  /**
+   * \brief \f$\mathcal{R}(\beta,\eta)=\int_0^\eta\cosh^2(\beta t)\,dt
+   *        = \frac{\eta}{2} + \frac{\sinh(2\beta\eta)}{4\beta}\f$.
+   *
+   * \f$\mathcal{R}(\beta,\eta)\to\eta\f$ as \f$\beta\to 0\f$.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_R(amrex::Real beta, amrex::Real eta) noexcept
+  {
+    return amrex::Real(0.5) * eta *
+           (amrex::Real(1.0) + interior_sinhc(amrex::Real(2.0) * beta * eta));
+  }
+
+  /** \brief \f$\mathcal{G}(\beta)=\mathcal{R}(\beta,1)\f$. */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_G(amrex::Real beta) noexcept
+  {
+    return interior_R(beta, amrex::Real(1.0));
+  }
+
+  /**
+   * \brief Global normalisation \f$\mathcal{N}\f$ that makes the mapping
+   *        preserve the total axis extent.  \c fac_min = 1/N.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_N(amrex::Real beta_lo, amrex::Real beta_hi, amrex::Real s_c) noexcept
+  {
+    return s_c * interior_G(beta_lo) +
+           (amrex::Real(1.0) - s_c) * interior_G(beta_hi);
+  }
+
+  /**
+   * \brief Closed-form Xi-space split that puts the clustering point at the
+   *        physical fraction \p p of the axis:
+   * \f[
+   *   s_c = \frac{p\,\mathcal{G}(\beta_{\mathrm{hi}})}
+   *              {(1-p)\,\mathcal{G}(\beta_{\mathrm{lo}})
+   *               + p\,\mathcal{G}(\beta_{\mathrm{hi}})}.
+   * \f]
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real interior_split(
+    amrex::Real p, amrex::Real beta_lo, amrex::Real beta_hi) noexcept
+  {
+    const amrex::Real G_lo = interior_G(beta_lo);
+    const amrex::Real G_hi = interior_G(beta_hi);
+    return p * G_hi / ((amrex::Real(1.0) - p) * G_lo + p * G_hi);
+  }
+
+  /**
+   * \brief Stretch factor \f$dx_{\mathrm{phys}}/d\xi
+   *        = \cosh^2(\beta_{\mathrm{side}}\eta)/\mathcal{N}\f$ at the
+   *        Xi-space fraction \p s of the axis.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real interior_fac(
+    amrex::Real beta_lo,
+    amrex::Real beta_hi,
+    amrex::Real s_c,
+    amrex::Real s) noexcept
+  {
+    const amrex::Real a = (s <= s_c)
+                            ? beta_lo * (s_c - s) / s_c
+                            : beta_hi * (s - s_c) / (amrex::Real(1.0) - s_c);
+    const amrex::Real c = std::cosh(a);
+    return c * c / interior_N(beta_lo, beta_hi, s_c);
+  }
+
+  /**
+   * \brief Physical-space fraction of the axis reached at the Xi-space
+   *        fraction \p s, i.e. \f$(x_{\mathrm{phys}}-x_{\mathrm{lo}})/L\f$.
+   *
+   * Integrating \c interior_fac from 0 to \p s.  Returns \p s exactly when
+   * both betas vanish.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_offset_norm(
+    amrex::Real beta_lo,
+    amrex::Real beta_hi,
+    amrex::Real s_c,
+    amrex::Real s) noexcept
+  {
+    const amrex::Real N = interior_N(beta_lo, beta_hi, s_c);
+    const amrex::Real xc_n = s_c * interior_G(beta_lo) / N;
+    if (s <= s_c) {
+      return xc_n - (s_c / N) * interior_R(beta_lo, (s_c - s) / s_c);
+    }
+    return xc_n + ((amrex::Real(1.0) - s_c) / N) *
+                    interior_R(beta_hi, (s - s_c) / (amrex::Real(1.0) - s_c));
+  }
+
+  /**
+   * \brief Inverse of \c interior_offset_norm: the Xi-space fraction
+   *        \f$s\f$ at which the physical fraction \p target is reached.
+   *
+   * No closed form (the offset involves
+   * \f$\eta + \sinh(2\beta\eta)/(2\beta)\f$), so this is a Newton iteration
+   * on f(s) = offset_norm(s) - target, whose derivative f' = fac(s) > 0, with
+   * a bisection safeguard on the bracket [lo, hi] that always contains the
+   * root because offset_norm is strictly increasing.  \p target must lie in
+   * [0,1]; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_offset_inv(
+    amrex::Real beta_lo,
+    amrex::Real beta_hi,
+    amrex::Real s_c,
+    amrex::Real target) noexcept
+  {
+    if (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS) {
+      return target;
+    }
+    auto lo = amrex::Real(0.0);
+    auto hi = amrex::Real(1.0);
+    amrex::Real s = target;
+    for (int it = 0; it < 50; ++it) {
+      const amrex::Real f =
+        interior_offset_norm(beta_lo, beta_hi, s_c, s) - target;
+      if (std::abs(f) < amrex::Real(1.0e-15)) {
+        break;
+      }
+      if (f > amrex::Real(0.0)) {
+        hi = s;
+      } else {
+        lo = s;
+      }
+      const amrex::Real fp = interior_fac(beta_lo, beta_hi, s_c, s);
+      amrex::Real s_new = s - f / fp;
+      if (s_new <= lo || s_new >= hi) {
+        s_new = amrex::Real(0.5) * (lo + hi);
+      }
+      const amrex::Real ds = std::abs(s_new - s);
+      s = s_new;
+      if (ds < amrex::Real(1.0e-13)) {
+        break;
+      }
+    }
+    return s;
+  }
+
+  /**
+   * \brief Physical coordinate of the cell centre with integer index
+   *        \p idx along axis \p idir.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  x_phys_cc(int idir, int idx, amrex::GeometryData const& gd) const noexcept
+  {
+    const amrex::Real xi =
+      gd.ProbLo()[idir] +
+      (static_cast<amrex::Real>(idx) + amrex::Real(0.5)) * gd.CellSize()[idir];
+    return x_phys_from_xi(idir, xi, gd);
+  }
+
+  /**
+   * \brief Physical size of domain along axis \p idir.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  domain_size_phys(int idir, amrex::GeometryData const& gd) const noexcept
+  {
+    return x_phys_from_xi(idir, gd.ProbHi()[idir], gd) -
+           x_phys_from_xi(idir, gd.ProbLo()[idir], gd);
+  }
+
+  /**
+   * \brief Physical coordinate of the face between cells \p idx-1 and
+   *        \p idx along axis \p idir.
+   *
+   * \p idx is the nodal index (face position), so face 0 sits at
+   * \c prob_lo and face N at \c prob_hi.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  x_phys_face(int idir, int idx, amrex::GeometryData const& gd) const noexcept
+  {
+    const amrex::Real xi =
+      gd.ProbLo()[idir] + static_cast<amrex::Real>(idx) * gd.CellSize()[idir];
+    return x_phys_from_xi(idir, xi, gd);
+  }
+
+  /**
+   * \brief Physical width of the cell with integer index \p idx along
+   *        axis \p idir.
+   *
+   * Exact for every supported map (it differences the two bounding face
+   * positions rather than assuming a local stretch factor).  Reduces to
+   * \c gd.CellSize()[idir] for \c Kind::Identity.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  dx_phys_cc(int idir, int idx, amrex::GeometryData const& gd) const noexcept
+  {
+    return x_phys_face(idir, idx + 1, gd) - x_phys_face(idir, idx, gd);
+  }
+
+  /**
+   * \brief Inverse of \c x_phys_from_xi: the \f$\xi\f$-space coordinate
+   *        whose image under the mapping is \p x_phys, along axis \p idir.
+   *
+   * Constant, ExpStretch and TanhStretch invert in closed form (\c log and
+   * \c atanh, see \c exp_offset_inv / \c tanh_offset_inv).  InteriorStretch
+   * does not, so \c interior_offset_inv runs a safeguarded Newton iteration
+   * on the monotone forward map, whose derivative is exactly
+   * \c interior_fac.  Use it to turn a physical
+   * position supplied in the inputs (a sampling-plane location, a probe
+   * position) into the coordinate that indexes the AMReX grid.
+   *
+   * \p x_phys is clamped to the physical image of \c [ProbLo, ProbHi]
+   * along \p idir, which keeps the \c log / \c atanh arguments in range;
+   * positions outside the domain are not meaningful for the callers this
+   * serves.  Callers that need a periodic image (e.g. a tiled inflow
+   * lookup) must wrap \p x_phys into the domain before calling.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real xi_from_x_phys(
+    int idir, amrex::Real x_phys, amrex::GeometryData const& gd) const noexcept
+  {
+    return xi_from_x_phys(idir, x_phys, gd.ProbLo()[idir], gd.ProbHi()[idir]);
+  }
+
+  /**
+   * \brief \c xi_from_x_phys for callers that hold no \c amrex::Geometry:
+   *        \p plo and \p phi are the Xi-space bounds of axis \p idir.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  xi_from_x_phys(int idir, amrex::Real x_phys, amrex::Real plo, amrex::Real phi)
+    const noexcept
+  {
+    const amrex::Real L = phi - plo;
+    switch (m_kind) {
+    case Kind::Identity:
+      return x_phys;
+
+    case Kind::Constant:
+      return plo + (x_phys - plo) / m_p[idir];
+
+    case Kind::ExpStretch: {
+      const amrex::Real beta = m_p[idir];
+      return (std::abs(beta) < BETA_EPS)
+               ? x_phys
+               : plo + L * exp_offset_inv(
+                             clamp01((x_phys - plo) / L), beta, m_q[idir]);
+    }
+
+    case Kind::TanhStretch: {
+      const amrex::Real beta = m_p[idir];
+      return (std::abs(beta) < BETA_EPS)
+               ? x_phys
+               : plo + L * tanh_offset_inv(clamp01((x_phys - plo) / L), beta);
+    }
+
+    case Kind::InteriorStretch: {
+      const amrex::Real beta_lo = m_p[idir];
+      const amrex::Real beta_hi = m_p2[idir];
+      return (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS)
+               ? x_phys
+               : plo + L * interior_offset_inv(
+                             beta_lo, beta_hi, m_p3[idir],
+                             clamp01((x_phys - plo) / L));
+    }
+    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      false, "MeshMapEvaluator::xi_from_x_phys: unhandled Kind -- a mesh map "
+             "was added without a case in this switch");
+    return std::numeric_limits<amrex::Real>::quiet_NaN();
+  }
+
+  /**
+   * \brief Lower-level helper: apply the mapping to an arbitrary
+   *        \f$\xi\f$-space coordinate along axis \p idir, given the
+   *        Xi-space bounds \p plo and \p phi of that axis.
+   *
+   * This is the form for callers that hold no \c amrex::Geometry, e.g.
+   * a turbulence-file reader describing the precursor's domain.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real x_phys_from_xi(
+    int idir, amrex::Real xi, amrex::Real plo, amrex::Real phi) const noexcept
+  {
+    const amrex::Real L = phi - plo;
+    switch (m_kind) {
+    case Kind::Identity:
+      return xi;
+
+    case Kind::Constant:
+      // Linear: X = plo + fac * (xi - plo).
+      return plo + m_p[idir] * (xi - plo);
+
+    case Kind::ExpStretch: {
+      const amrex::Real beta = m_p[idir];
+      return (std::abs(beta) < BETA_EPS)
+               ? xi
+               : plo + L * exp_offset_norm((xi - plo) / L, beta, m_q[idir]);
+    }
+
+    case Kind::TanhStretch: {
+      const amrex::Real beta = m_p[idir];
+      return (std::abs(beta) < BETA_EPS)
+               ? xi
+               : plo + L * tanh_offset_norm((xi - plo) / L, beta);
+    }
+
+    case Kind::InteriorStretch: {
+      const amrex::Real beta_lo = m_p[idir];
+      const amrex::Real beta_hi = m_p2[idir];
+      return (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS)
+               ? xi
+               : plo + L * interior_offset_norm(
+                             beta_lo, beta_hi, m_p3[idir], (xi - plo) / L);
+    }
+    }
+    // Not reached: every Kind above returns.  The switch deliberately has
+    // no default, so adding a Kind without handling it here is caught at
+    // compile time by -Wswitch.  Should one slip through anyway, fail
+    // loudly -- returning xi would silently degrade the run to an identity
+    // map, which looks plausible in the output and is very hard to spot.
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      false, "MeshMapEvaluator::x_phys_from_xi: unhandled Kind -- a mesh map "
+             "was added without a case in this switch");
+    return std::numeric_limits<amrex::Real>::quiet_NaN();
+  }
+
+  /**
+   * \brief Lower-level helper: apply the mapping to an arbitrary
+   *        \f$\xi\f$-space coordinate along axis \p idir.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real x_phys_from_xi(
+    int idir, amrex::Real xi, amrex::GeometryData const& gd) const noexcept
+  {
+    return x_phys_from_xi(idir, xi, gd.ProbLo()[idir], gd.ProbHi()[idir]);
+  }
+
+  /**
+   * \brief Physical coordinate of the face with nodal index \p idx along
+   *        axis \p idir on a Xi grid with bounds \p plo, \p phi and spacing
+   *        \p dxi.  Face 0 sits at \p plo.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real x_phys_face(
+    int idir,
+    int idx,
+    amrex::Real plo,
+    amrex::Real phi,
+    amrex::Real dxi) const noexcept
+  {
+    return x_phys_from_xi(
+      idir, plo + static_cast<amrex::Real>(idx) * dxi, plo, phi);
+  }
+
+  /**
+   * \brief Physical width of the cell with integer index \p idx along
+   *        axis \p idir on a Xi grid with bounds \p plo, \p phi and spacing
+   *        \p dxi.  Exact for every supported map.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real dx_phys_cc(
+    int idir,
+    int idx,
+    amrex::Real plo,
+    amrex::Real phi,
+    amrex::Real dxi) const noexcept
+  {
+    return x_phys_face(idir, idx + 1, plo, phi, dxi) -
+           x_phys_face(idir, idx, plo, phi, dxi);
+  }
+
+  /// Clamp a normalized coordinate into [0,1].  Public on purpose: device
+  /// code may need it and GPU builds have tripped over private statics.
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  clamp01(amrex::Real v) noexcept
+  {
+    return amrex::min(amrex::Real(1.0), amrex::max(amrex::Real(0.0), v));
+  }
+};
+
+} // namespace pele::physics
+
+#endif // PELE_PHYSICS_MESHMAP_EVALUATOR_H

--- a/Source/Utility/MeshMap/MeshMapEvaluator.H
+++ b/Source/Utility/MeshMap/MeshMapEvaluator.H
@@ -583,7 +583,8 @@ struct MeshMapEvaluator
   }
 
   /// Clamp a normalized coordinate into [0,1].  Public on purpose: device
-  /// code may need it and GPU builds have tripped over private statics. # codespell:ignore=statics
+  /// code may need it and GPU builds have tripped over private static
+  /// members.
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
   clamp01(amrex::Real v) noexcept
   {

--- a/Source/Utility/MeshMap/MeshMapEvaluatorInputs.H
+++ b/Source/Utility/MeshMap/MeshMapEvaluatorInputs.H
@@ -1,0 +1,192 @@
+#ifndef PELE_PHYSICS_MESHMAP_EVALUATOR_INPUTS_H
+#define PELE_PHYSICS_MESHMAP_EVALUATOR_INPUTS_H
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RealBox.H>
+#include <AMReX_SPACE.H>
+#include <AMReX_Vector.H>
+
+#include "MeshMapEvaluator.H"
+
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace pele::physics {
+
+/**
+ * \brief Build a MeshMapEvaluator from the same input-file block PeleLMeX
+ *        reads for \c geometry.mesh_mapping.
+ *
+ * Host-only.  Recognised (all names and defaults as in PeleLMeX's
+ * \c Source/Mesh/ map classes, so a precursor's lines can be copied
+ * verbatim into a utility's inputs):
+ *
+ *   geometry.mesh_mapping          = ConstantMap | ExpStretchMap |
+ *                                    TanhStretchMap | InteriorStretchMap
+ *   ConstantMap.scaling_factor     = fx fy fz            (default 1 1 1)
+ *   ExpStretchMap.direction        = d                   (default 1)
+ *   ExpStretchMap.wall_end         = lo | hi             (default lo)
+ *   ExpStretchMap.beta             = beta                (default 0)
+ *   TanhStretchMap.beta            = bx by bz            (default 0 0 0)
+ *   InteriorStretchMap.beta_lo     = bx by bz            (default 0 0 0)
+ *   InteriorStretchMap.beta_hi     = bx by bz            (default 0 0 0)
+ *   InteriorStretchMap.center_frac = cx cy cz            (default .5 .5 .5)
+ *   InteriorStretchMap.center      = x y z   physical; overrides center_frac
+ *
+ * \p probDomain is the Xi-space problem domain, needed only to turn an
+ * InteriorStretchMap physical \c center into a fraction of the axis.  When
+ * \c geometry.mesh_mapping is absent the result is \c Kind::Identity, so
+ * callers can test \c e.m_kind against it to mean "no mapping".
+ *
+ * Validation mirrors PeleLMeX's constructors (non-negative betas, positive
+ * scaling factors, interior clustering point strictly inside the domain)
+ * and aborts with the same intent on failure.
+ */
+inline MeshMapEvaluator
+make_evaluator_from_inputs(const amrex::RealBox& probDomain)
+{
+  using amrex::Real;
+  MeshMapEvaluator e;
+
+  amrex::ParmParse ppg("geometry");
+  std::string name;
+  if (ppg.query("mesh_mapping", name) == 0) {
+    return e; // Kind::Identity
+  }
+
+  if (name == "ConstantMap") {
+    amrex::ParmParse pp("ConstantMap");
+    amrex::Vector<Real> fac(AMREX_SPACEDIM, Real(1.0));
+    pp.queryarr("scaling_factor", fac, 0, AMREX_SPACEDIM);
+    e.m_kind = MeshMapEvaluator::Kind::Constant;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+      if (fac[d] <= std::numeric_limits<Real>::epsilon()) {
+        amrex::Abort(
+          "ConstantMap: All scaling factors must be strictly positive.");
+      }
+      e.m_p[d] = fac[d];
+      e.m_q[d] = -1;
+    }
+    return e;
+  }
+
+  if (name == "ExpStretchMap") {
+    amrex::ParmParse pp("ExpStretchMap");
+    int dir = 1;
+    pp.query("direction", dir);
+    if (dir < 0 || dir >= AMREX_SPACEDIM) {
+      amrex::Abort(
+        "ExpStretchMap: 'direction' must be in [0, AMREX_SPACEDIM).  "
+        "Set ExpStretchMap.direction to 0, 1, or 2.");
+    }
+    std::string wall{"lo"};
+    pp.query("wall_end", wall);
+    int wall_end = -1;
+    if (wall == "lo") {
+      wall_end = 0;
+    } else if (wall == "hi") {
+      wall_end = 1;
+    } else {
+      amrex::Abort(
+        "ExpStretchMap: 'wall_end' must be 'lo' or 'hi' (got '" + wall + "').");
+    }
+    Real beta = Real(0.0);
+    pp.query("beta", beta);
+    if (beta < Real(0.0)) {
+      amrex::Abort(
+        "ExpStretchMap: 'beta' must be non-negative (got " +
+        std::to_string(beta) + ").");
+    }
+    e.m_kind = MeshMapEvaluator::Kind::ExpStretch;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+      e.m_p[d] = (d == dir) ? beta : Real(0.0);
+      e.m_q[d] = (d == dir) ? wall_end : -1;
+    }
+    return e;
+  }
+
+  if (name == "TanhStretchMap") {
+    amrex::ParmParse pp("TanhStretchMap");
+    amrex::Vector<Real> beta(AMREX_SPACEDIM, Real(0.0));
+    pp.queryarr("beta", beta, 0, AMREX_SPACEDIM);
+    e.m_kind = MeshMapEvaluator::Kind::TanhStretch;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+      if (beta[d] < Real(0.0)) {
+        amrex::Abort(
+          "TanhStretchMap: beta values must be non-negative (got " +
+          std::to_string(beta[d]) + " on axis " + std::to_string(d) + ").");
+      }
+      e.m_p[d] = beta[d];
+      e.m_q[d] = -1;
+    }
+    return e;
+  }
+
+  if (name == "InteriorStretchMap") {
+    // Mirrors PeleLMeX's InteriorStretchMap constructor: the clustering
+    // point is a fraction of the axis (physical `center` wins), and the
+    // Xi-space split s_c that places it there follows in closed form.
+    constexpr Real SPLIT_EPS = Real(1.0e-12);
+    amrex::ParmParse pp("InteriorStretchMap");
+    amrex::Vector<Real> blo(AMREX_SPACEDIM, Real(0.0));
+    amrex::Vector<Real> bhi(AMREX_SPACEDIM, Real(0.0));
+    pp.queryarr("beta_lo", blo, 0, AMREX_SPACEDIM);
+    pp.queryarr("beta_hi", bhi, 0, AMREX_SPACEDIM);
+    amrex::Vector<Real> cfrac(AMREX_SPACEDIM, Real(0.5));
+    pp.queryarr("center_frac", cfrac, 0, AMREX_SPACEDIM);
+    if (pp.contains("center")) {
+      amrex::Vector<Real> cphys(AMREX_SPACEDIM, Real(0.0));
+      pp.getarr("center", cphys, 0, AMREX_SPACEDIM);
+      for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        cfrac[d] = (cphys[d] - probDomain.lo(d)) / probDomain.length(d);
+      }
+    }
+    e.m_kind = MeshMapEvaluator::Kind::InteriorStretch;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+      if (blo[d] < Real(0.0) || bhi[d] < Real(0.0)) {
+        amrex::Abort(
+          "InteriorStretchMap: beta_lo/beta_hi must be non-negative (got " +
+          std::to_string(blo[d]) + " / " + std::to_string(bhi[d]) +
+          " on axis " + std::to_string(d) + ").");
+      }
+      const Real beta_lo =
+        (blo[d] < MeshMapEvaluator::BETA_EPS) ? Real(0.0) : blo[d];
+      const Real beta_hi =
+        (bhi[d] < MeshMapEvaluator::BETA_EPS) ? Real(0.0) : bhi[d];
+      const bool stretched = (beta_lo > Real(0.0)) || (beta_hi > Real(0.0));
+      if (stretched && (cfrac[d] <= Real(0.0) || cfrac[d] >= Real(1.0))) {
+        amrex::Abort(
+          "InteriorStretchMap: the clustering point must lie strictly "
+          "inside the domain on axis " +
+          std::to_string(d) + " (got a fraction of " +
+          std::to_string(cfrac[d]) +
+          ").  Use ExpStretchMap for clustering at a boundary.");
+      }
+      const Real cf =
+        std::fmin(std::fmax(cfrac[d], SPLIT_EPS), Real(1.0) - SPLIT_EPS);
+      const Real s_c = std::fmin(
+        std::fmax(
+          MeshMapEvaluator::interior_split(cf, beta_lo, beta_hi), SPLIT_EPS),
+        Real(1.0) - SPLIT_EPS);
+      e.m_p[d] = beta_lo;
+      e.m_p2[d] = beta_hi;
+      e.m_p3[d] = s_c;
+      e.m_q[d] = -1;
+    }
+    return e;
+  }
+
+  amrex::Abort(
+    "make_evaluator_from_inputs(): unrecognised geometry.mesh_mapping '" +
+    name +
+    "'.  Supported: ConstantMap, ExpStretchMap, TanhStretchMap, "
+    "InteriorStretchMap.");
+  return e;
+}
+
+} // namespace pele::physics
+
+#endif // PELE_PHYSICS_MESHMAP_EVALUATOR_INPUTS_H

--- a/Source/Utility/TurbInflow/Make.package
+++ b/Source/Utility/TurbInflow/Make.package
@@ -3,3 +3,5 @@ CEXE_sources += turbinflow.cpp
 
 VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/TurbInflow
 INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/TurbInflow
+# turbinflow.H includes the header-only MeshMapEvaluator
+INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/MeshMap

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -28,6 +28,12 @@
 // without the trailer are, by declaration, uniform in physical position.
 #define PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR 1
 
+// Feature macro: add_turb() samples a file carrying a MESHMAP trailer by
+// inverting the file's map (interpolation in the precursor's Xi), and the
+// file_map() / file_transverse_dx_range() accessors exist.  Consumers that
+// previously refused, or warned about, mapped files can #ifdef on this.
+#define PELEPHYSICS_TURBINFLOW_SAMPLES_MESHMAP 1
+
 namespace pele::physics::turbinflow {
 
 AMREX_ENUM(TurbInterpType, linear, quadratic);

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -6,6 +6,10 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_ParmParse.H>
 
+// Relative to this header so that a build which lists TurbInflow but not
+// Source/Utility/MeshMap among its include directories still compiles.
+#include "../MeshMap/MeshMapEvaluator.H"
+
 // Feature macro: this PelePhysics provides the TurbInflow::add_turb()
 // overload that takes the physical positions of the inflow-face cell
 // centres explicitly, rather than deriving them from an amrex::Geometry.
@@ -18,10 +22,10 @@
 // land independently.
 #define PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB 1
 
-// Feature macro: the HDR reader understands the optional MESHMAP_V1 trailer
-// that tags a turbulence file as uniform in a precursor's computational (Xi)
-// coordinate rather than in physical position.  Files without the trailer
-// are, by declaration, uniform in physical position.
+// Feature macro: the HDR reader understands the optional MESHMAP trailer
+// (V1 or V2) that tags a turbulence file as uniform in a precursor's
+// computational (Xi) coordinate rather than in physical position.  Files
+// without the trailer are, by declaration, uniform in physical position.
 #define PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR 1
 
 namespace pele::physics::turbinflow {
@@ -84,16 +88,19 @@ struct TurbParm
   int kmax; // Number of plane in Turbfile
 
   // Optional coordinate-mapping descriptor of the turbulence file, read
-  // from the MESHMAP_V1 trailer of HDR (see the file-format notes in
+  // from the MESHMAP trailer of HDR (see the file-format notes in
   // turbinflow.cpp).  When present, the file's transverse grid is uniform
   // in the *computational* (Xi) coordinate of the precursor that produced
   // it, and a physical position must be inverted through this map before
-  // being turned into a file index.  Absent trailer => has_map == false and
-  // the file is uniform in physical position.
+  // being turned into a file index -- add_turb() does so.  Absent trailer
+  // => has_map == false and the file is uniform in physical position.
+  //
+  // The evaluator's axis slots 0 and 1 hold the payload for the file's
+  // two transverse directions (in the file's own order), and map_xi_lo /
+  // map_xi_hi the precursor's Xi-space bounds along them, i.e. the file's
+  // own transverse extent before the two ghost layers.
   bool has_map = false;
-  amrex::GpuArray<int, 2> map_kind = {{0, 0}};
-  amrex::GpuArray<amrex::Real, 2> map_p = {{0.0, 0.0}};
-  amrex::GpuArray<int, 2> map_q = {{-1, -1}};
+  pele::physics::MeshMapEvaluator map{};
   amrex::GpuArray<amrex::Real, 2> map_xi_lo = {{0.0, 0.0}};
   amrex::GpuArray<amrex::Real, 2> map_xi_hi = {{0.0, 0.0}};
 };
@@ -171,7 +178,9 @@ public:
    * Returns false when no turb file acts on that face.  Intended for
    * resolution-consistency diagnostics: the ratio of the target grid's
    * local spacing to this value is what decides whether the injected
-   * field can fill the grid's resolved scales.
+   * field can fill the grid's resolved scales.  For a mesh-mapped file
+   * (\c has_map) the physical spacing varies across the plane and this
+   * reports its mean; see \c file_transverse_dx_range for the extremes.
    */
   bool file_transverse_dx(
     const int dir,
@@ -180,13 +189,47 @@ public:
     amrex::Real& dx_tdir2) const;
 
   /**
+   * \brief Smallest and largest physical transverse cell spacing of the
+   *        turbulence file feeding the (\p dir, \p side) face, in case
+   *        units, for each of the two transverse directions.
+   *
+   * Equal to \c file_transverse_dx for a physically-uniform file.  Returns
+   * false when no turb file acts on that face.
+   */
+  bool file_transverse_dx_range(
+    const int dir,
+    const amrex::Orientation::Side& side,
+    amrex::Real dx_min[2],
+    amrex::Real dx_max[2]) const;
+
+  /**
    * \brief Whether the turbulence file feeding the (\p dir, \p side) face
-   *        carries a MESHMAP_V1 trailer, i.e. is uniform in a precursor's
+   *        carries a MESHMAP trailer, i.e. is uniform in a precursor's
    *        computational coordinate rather than in physical position.
    *
    * Returns false when no turb file acts on that face.
    */
   bool file_has_map(const int dir, const amrex::Orientation::Side& side) const;
+
+  /**
+   * \brief The mesh-mapping descriptor of the turbulence file feeding the
+   *        (\p dir, \p side) face.
+   *
+   * Returns -1 when no turb file acts on that face, 0 when the file is
+   * uniform in physical position (\p map is then left untouched), and 1
+   * when it carries a MESHMAP trailer, in which case \p map holds the
+   * precursor's map with the file's two transverse directions in axis
+   * slots 0 and 1 and \p xi_lo / \p xi_hi their Xi-space bounds.  Lets a
+   * solver compare the file's map with its own: equal maps and bounds
+   * mean the file is injected by exact index, anything else by
+   * interpolation in the file's Xi coordinate.
+   */
+  int file_map(
+    const int dir,
+    const amrex::Orientation::Side& side,
+    pele::physics::MeshMapEvaluator& map,
+    amrex::Real xi_lo[2],
+    amrex::Real xi_hi[2]) const;
 
   bool is_initialized() const { return turbinflow_initialized; }
 
@@ -211,6 +254,18 @@ public:
     const amrex::Vector<amrex::Real>& y,
     amrex::Real z,
     amrex::FArrayBox& v);
+
+  //! Turbulence-file coordinate of a physical position (already in file
+  //! units) along transverse direction \p idim of \p a_tp: the identity
+  //! for a physically-uniform file, the inverse of the file's map for a
+  //! mesh-mapped one (with the tile_periodic wrap applied first).
+  static amrex::Real
+  file_coordinate(const TurbParm& a_tp, int idim, amrex::Real x_file_phys);
+
+  //! Smallest and largest physical transverse spacing of \p a_tp's file in
+  //! case units, per transverse direction.
+  static void transverse_dx_range(
+    const TurbParm& a_tp, amrex::Real dx_min[2], amrex::Real dx_max[2]);
 
   static void set_turb(
     int normDir,

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -282,6 +282,10 @@ public:
     const int dcomp);
 
 private:
+  //! The TurbParm acting on the (\p dir, \p side) face, or nullptr.
+  const TurbParm*
+  find_turbparm(const int dir, const amrex::Orientation::Side& side) const;
+
   amrex::Vector<TurbParm> tp;
   bool turbinflow_initialized = false;
 };

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -1,5 +1,7 @@
 #include <turbinflow.H>
 
+#include <algorithm>
+
 namespace pele::physics::turbinflow {
 void
 TurbInflow::init(amrex::Geometry const& /*geom*/)
@@ -370,33 +372,43 @@ TurbInflow::file_transverse_dx(
   amrex::Real& dx_tdir1,
   amrex::Real& dx_tdir2) const
 {
-  for (const auto& tpn : tp) {
-    if (tpn.dir == dir && tpn.side == side) {
-      if (!tpn.has_map) {
-        dx_tdir1 = tpn.dx[0] / tpn.turb_scale_loc;
-        dx_tdir2 = tpn.dx[1] / tpn.turb_scale_loc;
-      } else {
-        // Mean physical spacing: the file's physical transverse extent over
-        // its interior cell count.
-        amrex::Real mean[2];
-        for (int idim = 0; idim < 2; ++idim) {
-          const amrex::Real xlo = tpn.map.x_phys_from_xi(
-            idim, tpn.map_xi_lo[idim], tpn.map_xi_lo[idim],
-            tpn.map_xi_hi[idim]);
-          const amrex::Real xhi = tpn.map.x_phys_from_xi(
-            idim, tpn.map_xi_hi[idim], tpn.map_xi_lo[idim],
-            tpn.map_xi_hi[idim]);
-          mean[idim] = (xhi - xlo) /
-                       static_cast<amrex::Real>(tpn.npboxcells[idim]) /
-                       tpn.turb_scale_loc;
-        }
-        dx_tdir1 = mean[0];
-        dx_tdir2 = mean[1];
-      }
-      return true;
-    }
+  const TurbParm* tpn = find_turbparm(dir, side);
+  if (tpn == nullptr) {
+    return false;
   }
-  return false;
+  if (!tpn->has_map) {
+    // tp.dx lives in turb-file units; queried coordinates are multiplied
+    // by turb_scale_loc before the lookup, so the equivalent spacing in
+    // case units is dx / turb_scale_loc.
+    dx_tdir1 = tpn->dx[0] / tpn->turb_scale_loc;
+    dx_tdir2 = tpn->dx[1] / tpn->turb_scale_loc;
+    return true;
+  }
+  // Mean physical spacing: the file's physical transverse extent over its
+  // interior cell count.
+  amrex::Real mean[2];
+  for (int idim = 0; idim < 2; ++idim) {
+    const amrex::Real xlo = tpn->map.x_phys_from_xi(
+      idim, tpn->map_xi_lo[idim], tpn->map_xi_lo[idim], tpn->map_xi_hi[idim]);
+    const amrex::Real xhi = tpn->map.x_phys_from_xi(
+      idim, tpn->map_xi_hi[idim], tpn->map_xi_lo[idim], tpn->map_xi_hi[idim]);
+    mean[idim] = (xhi - xlo) / static_cast<amrex::Real>(tpn->npboxcells[idim]) /
+                 tpn->turb_scale_loc;
+  }
+  dx_tdir1 = mean[0];
+  dx_tdir2 = mean[1];
+  return true;
+}
+
+const TurbParm*
+TurbInflow::find_turbparm(
+  const int dir, const amrex::Orientation::Side& side) const
+{
+  auto it =
+    std::find_if(tp.begin(), tp.end(), [dir, side](const TurbParm& tpn) {
+      return tpn.dir == dir && tpn.side == side;
+    });
+  return (it != tp.end()) ? &(*it) : nullptr;
 }
 
 bool
@@ -406,35 +418,12 @@ TurbInflow::file_transverse_dx_range(
   amrex::Real dx_min[2],
   amrex::Real dx_max[2]) const
 {
-  auto it =
-    std::find_if(tp.begin(), tp.end(), [dir, side](const TurbParm& tpn) {
-      return tpn.dir == dir && tpn.side == side;
-    });
-
-  if (it != tp.end()) {
-    transverse_dx_range(*it, dx_min, dx_max);
-    return true;
+  const TurbParm* tpn = find_turbparm(dir, side);
+  if (tpn == nullptr) {
+    return false;
   }
-  return false;
-}
-
-bool
-TurbInflow::file_transverse_dx_range(
-  const int dir,
-  const amrex::Orientation::Side& side,
-  amrex::Real dx_min[2],
-  amrex::Real dx_max[2]) const
-{
-  auto it =
-    std::find_if(tp.begin(), tp.end(), [dir, side](const TurbParm& tpn) {
-      return tpn.dir == dir && tpn.side == side;
-    });
-
-  if (it != tp.end()) {
-    transverse_dx_range(*it, dx_min, dx_max);
-    return true;
-  }
-  return false;
+  transverse_dx_range(*tpn, dx_min, dx_max);
+  return true;
 }
 
 int
@@ -445,20 +434,19 @@ TurbInflow::file_map(
   amrex::Real xi_lo[2],
   amrex::Real xi_hi[2]) const
 {
-  for (const auto& tpn : tp) {
-    if (tpn.dir == dir && tpn.side == side) {
-      if (!tpn.has_map) {
-        return 0;
-      }
-      map = tpn.map;
-      xi_lo[0] = tpn.map_xi_lo[0];
-      xi_lo[1] = tpn.map_xi_lo[1];
-      xi_hi[0] = tpn.map_xi_hi[0];
-      xi_hi[1] = tpn.map_xi_hi[1];
-      return 1;
-    }
+  const TurbParm* tpn = find_turbparm(dir, side);
+  if (tpn == nullptr) {
+    return -1;
   }
-  return -1;
+  if (!tpn->has_map) {
+    return 0;
+  }
+  map = tpn->map;
+  xi_lo[0] = tpn->map_xi_lo[0];
+  xi_lo[1] = tpn->map_xi_lo[1];
+  xi_hi[0] = tpn->map_xi_hi[0];
+  xi_hi[1] = tpn->map_xi_hi[1];
+  return 1;
 }
 
 void

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -406,11 +406,33 @@ TurbInflow::file_transverse_dx_range(
   amrex::Real dx_min[2],
   amrex::Real dx_max[2]) const
 {
-  for (const auto& tpn : tp) {
-    if (tpn.dir == dir && tpn.side == side) {
-      transverse_dx_range(tpn, dx_min, dx_max);
-      return true;
-    }
+  auto it =
+    std::find_if(tp.begin(), tp.end(), [dir, side](const TurbParm& tpn) {
+      return tpn.dir == dir && tpn.side == side;
+    });
+
+  if (it != tp.end()) {
+    transverse_dx_range(*it, dx_min, dx_max);
+    return true;
+  }
+  return false;
+}
+
+bool
+TurbInflow::file_transverse_dx_range(
+  const int dir,
+  const amrex::Orientation::Side& side,
+  amrex::Real dx_min[2],
+  amrex::Real dx_max[2]) const
+{
+  auto it =
+    std::find_if(tp.begin(), tp.end(), [dir, side](const TurbParm& tpn) {
+      return tpn.dir == dir && tpn.side == side;
+    });
+
+  if (it != tp.end()) {
+    transverse_dx_range(*it, dx_min, dx_max);
+    return true;
   }
   return false;
 }

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -58,14 +58,16 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
                        << tp[n].turb_scale_vel << ") \n";
       }
 
-      // Get the turbcenter on the injection face
+      // Get the turbcenter on the injection face.  Required for a file that
+      // is uniform in physical position; optional for a mesh-mapped file
+      // (see the MESHMAP trailer below), whose default centre follows from
+      // the trailer.
       amrex::Vector<amrex::Real> turb_center(AMREX_SPACEDIM - 1, 0);
-      pp.getarr("turb_center", turb_center);
-      AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        turb_center.size() == AMREX_SPACEDIM - 1,
-        "turb_center must have AMREX_SPACEDIM-1 elements");
-      for (amrex::Real& tc : turb_center) {
-        tc *= tp[n].turb_scale_loc;
+      const bool has_turb_center = pp.queryarr("turb_center", turb_center) != 0;
+      if (has_turb_center) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+          turb_center.size() == AMREX_SPACEDIM - 1,
+          "turb_center must have AMREX_SPACEDIM-1 elements");
       }
 
       pp.query("turb_nplane", tp[n].nplane);
@@ -117,26 +119,10 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         tp[n].npboxcells[0] = npts[0] - 3;, tp[n].npboxcells[1] = npts[1] - 3;
         , tp[n].npboxcells[2] = npts[2];)
 
-      // Center the turbulence
-      AMREX_D_TERM(
-        tp[n].pboxlo[0] = turb_center[0] - 0.5 * tp[n].pboxsize[0];
-        , tp[n].pboxlo[1] = turb_center[1] - 0.5 * tp[n].pboxsize[1];
-        , tp[n].pboxlo[2] = 0.0;)
-
-      if (tp[n].verbose > 0) {
-        if (tp[n].turb_scale_loc == 0.0) {
-          amrex::Abort(
-            "TurbInflow::init(): turb_scale_loc must be non-zero for " +
-            tp_list[n]);
-        }
-        // The file is uniformly spaced by construction (the HDR carries only
-        // npts and probsize).  Report the equivalent spacing in case units so
-        // that it can be compared against the target grid's spacing on the
-        // injection face -- see PeleLMeX's turbInflow resolution check.
-        amrex::Print() << "   transverse spacing of " << tp_list[n]
-                       << " in case units: "
-                       << tp[n].dx[0] / tp[n].turb_scale_loc << " x "
-                       << tp[n].dx[1] / tp[n].turb_scale_loc << "\n";
+      if (tp[n].turb_scale_loc == 0.0) {
+        amrex::Abort(
+          "TurbInflow::init(): turb_scale_loc must be non-zero for " +
+          tp_list[n]);
       }
 
       // Swirl type: we can't load more planes than are available
@@ -173,45 +159,161 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
       // position.  Format (one line per transverse direction, in the file's
       // own transverse order):
       //
-      //   MESHMAP_V1
-      //   <kind> <p> <q> <xi_lo> <xi_hi>
-      //   <kind> <p> <q> <xi_lo> <xi_hi>
+      //   MESHMAP_V2
+      //   <kind> <p> <p2> <p3> <q> <xi_lo> <xi_hi>
+      //   <kind> <p> <p2> <p3> <q> <xi_lo> <xi_hi>
       //
-      // kind/p/q follow PeleLMeX's MeshMapEvaluator (0 identity, 1 constant,
-      // 2 exp stretch, 3 tanh stretch); xi_lo/xi_hi are the precursor's
-      // computational-domain bounds along that axis, which the inverse map
-      // needs.  A trailer marks the file as uniform in the precursor's Xi
-      // coordinate rather than in physical position.
+      // kind/p/p2/p3/q are the MeshMapEvaluator payload for that axis
+      // (0 identity, 1 constant, 2 exp stretch, 3 tanh stretch, 4 interior
+      // stretch); xi_lo/xi_hi are the precursor's computational-domain
+      // bounds along that axis, which the inverse map needs.  The earlier
+      // MESHMAP_V1 form, <kind> <p> <q> <xi_lo> <xi_hi>, is read with
+      // p2 = p3 = 0.  A trailer marks the file as uniform in the precursor's
+      // Xi coordinate rather than in physical position; add_turb() inverts
+      // the map before indexing the file.
       std::string token;
-      if ((is >> token) && token == "MESHMAP_V1") {
+      if ((is >> token) && (token == "MESHMAP_V1" || token == "MESHMAP_V2")) {
+        const bool v2 = (token == "MESHMAP_V2");
+        int kind[2] = {0, 0};
         for (int idim = 0; idim < 2; ++idim) {
-          is >> tp[n].map_kind[idim] >> tp[n].map_p[idim] >>
-            tp[n].map_q[idim] >> tp[n].map_xi_lo[idim] >> tp[n].map_xi_hi[idim];
+          amrex::Real p = 0.0;
+          amrex::Real p2 = 0.0;
+          amrex::Real p3 = 0.0;
+          int q = -1;
+          if (v2) {
+            is >> kind[idim] >> p >> p2 >> p3 >> q;
+          } else {
+            is >> kind[idim] >> p >> q;
+          }
+          is >> tp[n].map_xi_lo[idim] >> tp[n].map_xi_hi[idim];
+          tp[n].map.m_p[idim] = p;
+          tp[n].map.m_p2[idim] = p2;
+          tp[n].map.m_p3[idim] = p3;
+          tp[n].map.m_q[idim] = q;
         }
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-          is.good(),
-          "TurbInflow::init(): malformed MESHMAP_V1 trailer in " + turb_header);
-        tp[n].has_map = true;
-        if (tp[n].verbose > 0) {
-          amrex::Print() << "   " << tp_list[n]
-                         << " carries a MESHMAP_V1 trailer: file is uniform "
-                            "in the precursor's Xi coordinate (kinds "
-                         << tp[n].map_kind[0] << ", " << tp[n].map_kind[1]
-                         << ")\n";
+          is.good(), "TurbInflow::init(): malformed " + token + " trailer in " +
+                       turb_header);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+          kind[0] == kind[1],
+          "TurbInflow::init(): " + token + " trailer in " + turb_header +
+            " names two different map kinds; a precursor has one map");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+          kind[0] >= static_cast<int>(MeshMapEvaluator::Kind::Identity) &&
+            kind[0] <=
+              static_cast<int>(MeshMapEvaluator::Kind::InteriorStretch),
+          "TurbInflow::init(): unknown map kind in " + token + " trailer of " +
+            turb_header);
+        for (int idim = 0; idim < 2; ++idim) {
+          AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            tp[n].map_xi_hi[idim] > tp[n].map_xi_lo[idim],
+            "TurbInflow::init(): " + token + " trailer in " + turb_header +
+              " has xi_hi <= xi_lo");
         }
-        // The sampling path below converts case positions to file indices
-        // with a single affine expression, i.e. it assumes the file is
-        // uniform in physical position.  Until it can invert the file's map
-        // (next step of the stretched-mesh work), refuse rather than inject
-        // a silently mis-sampled field.
-        amrex::Abort(
-          "TurbInflow::init(): turbulence file " + tp[n].m_turb_file +
-          " was generated on a mesh-mapped precursor (MESHMAP_V1 trailer). "
-          "Sampling such a file is not yet supported by this TurbInflow.");
+        tp[n].map.m_kind = static_cast<MeshMapEvaluator::Kind>(kind[0]);
+        tp[n].has_map = true;
+        // The trailer's Xi bounds are exact while the header's probsize may
+        // have been written with limited precision; derive the file's Xi
+        // spacing from the trailer so that the inverse map and the index
+        // lookup agree to round-off, after checking the two are consistent.
+        for (int idim = 0; idim < 2; ++idim) {
+          const amrex::Real L = tp[n].map_xi_hi[idim] - tp[n].map_xi_lo[idim];
+          const amrex::Real dx_tr =
+            L / static_cast<amrex::Real>(tp[n].npboxcells[idim]);
+          AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            std::abs(dx_tr - tp[n].dx[idim]) <= 1.0e-5 * tp[n].dx[idim],
+            "TurbInflow::init(): " + token + " trailer of " + turb_header +
+              " gives a Xi extent inconsistent with the header's probsize");
+          tp[n].dx[idim] = dx_tr;
+          tp[n].dxinv[idim] = 1.0 / dx_tr;
+          tp[n].pboxsize[idim] = L;
+        }
+        if (tp[n].verbose > 0) {
+          amrex::Print() << "   " << tp_list[n] << " carries a " << token
+                         << " trailer: file is uniform in the precursor's Xi "
+                            "coordinate (map kind "
+                         << kind[0] << ")\n";
+        }
       } else if (!token.empty() && !is.eof()) {
         amrex::Print() << "TurbInflow: WARNING ignoring unrecognised trailing "
                           "content in "
                        << turb_header << " starting at '" << token << "'\n";
+      }
+
+      // Center the turbulence.  For a physically-uniform file turb_center
+      // is in case units and the file is placed around it.  For a
+      // mesh-mapped file the sampling coordinate is the precursor's Xi
+      // (add_turb() inverts the map), so the natural placement is the
+      // precursor's own: pboxlo = xi_lo, i.e. turb_center = (xi_lo+xi_hi)/2
+      // in the file's Xi units, and that is the default; a supplied
+      // turb_center is taken in those same Xi units (unscaled) and shifts
+      // the pattern within the plane.
+      if (tp[n].has_map) {
+        for (int idim = 0; idim < 2; ++idim) {
+          const amrex::Real xi_mid =
+            0.5 * (tp[n].map_xi_lo[idim] + tp[n].map_xi_hi[idim]);
+          if (!has_turb_center) {
+            turb_center[idim] = xi_mid;
+          } else {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+              turb_center[idim] >= tp[n].map_xi_lo[idim] &&
+                turb_center[idim] <= tp[n].map_xi_hi[idim],
+              "TurbInflow::init(): turb_center for a mesh-mapped turbulence "
+              "file is in the file's Xi units and must lie within "
+              "[xi_lo, xi_hi] of its MESHMAP trailer");
+          }
+        }
+        if (tp[n].verbose > 0) {
+          amrex::Print() << "   turb_center of " << tp_list[n]
+                         << " in file Xi units: " << turb_center[0] << " "
+                         << turb_center[1]
+                         << (has_turb_center ? "" : " (default)")
+                         << ", physical (case units): "
+                         << tp[n].map.x_phys_from_xi(
+                              0, turb_center[0], tp[n].map_xi_lo[0],
+                              tp[n].map_xi_hi[0]) /
+                              tp[n].turb_scale_loc
+                         << " "
+                         << tp[n].map.x_phys_from_xi(
+                              1, turb_center[1], tp[n].map_xi_lo[1],
+                              tp[n].map_xi_hi[1]) /
+                              tp[n].turb_scale_loc
+                         << "\n";
+        }
+      } else {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+          has_turb_center,
+          "turbinflow." + tp_list[n] +
+            ".turb_center is required for a turbulence file that is uniform "
+            "in physical position (no MESHMAP trailer)");
+        for (amrex::Real& tc : turb_center) {
+          tc *= tp[n].turb_scale_loc;
+        }
+      }
+      AMREX_D_TERM(
+        tp[n].pboxlo[0] = turb_center[0] - 0.5 * tp[n].pboxsize[0];
+        , tp[n].pboxlo[1] = turb_center[1] - 0.5 * tp[n].pboxsize[1];
+        , tp[n].pboxlo[2] = 0.0;)
+
+      if (tp[n].verbose > 0) {
+        // Report the file's transverse spacing in case units so that it can
+        // be compared against the target grid's spacing on the injection
+        // face -- see PeleLMeX's turbInflow resolution check.  A
+        // mesh-mapped file is uniform in Xi only, so give its physical
+        // range.
+        amrex::Real dmin[2] = {0.0, 0.0};
+        amrex::Real dmax[2] = {0.0, 0.0};
+        transverse_dx_range(tp[n], dmin, dmax);
+        amrex::Print() << "   transverse spacing of " << tp_list[n]
+                       << " in case units: ";
+        for (int idim = 0; idim < 2; ++idim) {
+          if (tp[n].has_map) {
+            amrex::Print() << "[" << dmin[idim] << ", " << dmax[idim] << "]";
+          } else {
+            amrex::Print() << dmin[idim];
+          }
+          amrex::Print() << (idim == 0 ? " x " : "\n");
+        }
       }
       is.close();
     }
@@ -234,6 +336,33 @@ TurbInflow::file_has_map(
   return found ? any_has_map : false;
 }
 
+void
+TurbInflow::transverse_dx_range(
+  const TurbParm& a_tp, amrex::Real dx_min[2], amrex::Real dx_max[2])
+{
+  // tp.dx lives in turb-file units; queried coordinates are multiplied by
+  // turb_scale_loc before the lookup, so the equivalent spacing in case
+  // units is dx / turb_scale_loc.  A mesh-mapped file is uniform in Xi:
+  // difference the physical face positions of each interior cell instead.
+  for (int idim = 0; idim < 2; ++idim) {
+    if (!a_tp.has_map) {
+      dx_min[idim] = a_tp.dx[idim] / a_tp.turb_scale_loc;
+      dx_max[idim] = dx_min[idim];
+      continue;
+    }
+    amrex::Real dmin = std::numeric_limits<amrex::Real>::max();
+    amrex::Real dmax = 0.0;
+    for (int i = 0; i < a_tp.npboxcells[idim]; ++i) {
+      const amrex::Real d = a_tp.map.dx_phys_cc(
+        idim, i, a_tp.map_xi_lo[idim], a_tp.map_xi_hi[idim], a_tp.dx[idim]);
+      dmin = amrex::min(dmin, d);
+      dmax = amrex::max(dmax, d);
+    }
+    dx_min[idim] = dmin / a_tp.turb_scale_loc;
+    dx_max[idim] = dmax / a_tp.turb_scale_loc;
+  }
+}
+
 bool
 TurbInflow::file_transverse_dx(
   const int dir,
@@ -243,15 +372,71 @@ TurbInflow::file_transverse_dx(
 {
   for (const auto& tpn : tp) {
     if (tpn.dir == dir && tpn.side == side) {
-      // tp.dx lives in turb-file units; queried coordinates are multiplied
-      // by turb_scale_loc before the lookup, so the equivalent spacing in
-      // case units is dx / turb_scale_loc.
-      dx_tdir1 = tpn.dx[0] / tpn.turb_scale_loc;
-      dx_tdir2 = tpn.dx[1] / tpn.turb_scale_loc;
+      if (!tpn.has_map) {
+        dx_tdir1 = tpn.dx[0] / tpn.turb_scale_loc;
+        dx_tdir2 = tpn.dx[1] / tpn.turb_scale_loc;
+      } else {
+        // Mean physical spacing: the file's physical transverse extent over
+        // its interior cell count.
+        amrex::Real mean[2];
+        for (int idim = 0; idim < 2; ++idim) {
+          const amrex::Real xlo = tpn.map.x_phys_from_xi(
+            idim, tpn.map_xi_lo[idim], tpn.map_xi_lo[idim],
+            tpn.map_xi_hi[idim]);
+          const amrex::Real xhi = tpn.map.x_phys_from_xi(
+            idim, tpn.map_xi_hi[idim], tpn.map_xi_lo[idim],
+            tpn.map_xi_hi[idim]);
+          mean[idim] = (xhi - xlo) /
+                       static_cast<amrex::Real>(tpn.npboxcells[idim]) /
+                       tpn.turb_scale_loc;
+        }
+        dx_tdir1 = mean[0];
+        dx_tdir2 = mean[1];
+      }
       return true;
     }
   }
   return false;
+}
+
+bool
+TurbInflow::file_transverse_dx_range(
+  const int dir,
+  const amrex::Orientation::Side& side,
+  amrex::Real dx_min[2],
+  amrex::Real dx_max[2]) const
+{
+  for (const auto& tpn : tp) {
+    if (tpn.dir == dir && tpn.side == side) {
+      transverse_dx_range(tpn, dx_min, dx_max);
+      return true;
+    }
+  }
+  return false;
+}
+
+int
+TurbInflow::file_map(
+  const int dir,
+  const amrex::Orientation::Side& side,
+  pele::physics::MeshMapEvaluator& map,
+  amrex::Real xi_lo[2],
+  amrex::Real xi_hi[2]) const
+{
+  for (const auto& tpn : tp) {
+    if (tpn.dir == dir && tpn.side == side) {
+      if (!tpn.has_map) {
+        return 0;
+      }
+      map = tpn.map;
+      xi_lo[0] = tpn.map_xi_lo[0];
+      xi_lo[1] = tpn.map_xi_lo[1];
+      xi_hi[0] = tpn.map_xi_hi[0];
+      xi_hi[1] = tpn.map_xi_hi[1];
+      return 1;
+    }
+  }
+  return -1;
 }
 
 void
@@ -338,13 +523,15 @@ TurbInflow::add_turb(
 
       // 0 and 1 are the two transverse directions.  turb_scale_loc is a
       // per-TurbParm quantity, so the scaling is applied here rather than
-      // once by the caller.
+      // once by the caller.  For a mesh-mapped file the scaled physical
+      // position is then inverted through the file's map into the
+      // precursor's Xi coordinate, which is what indexes the file.
       amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);
       for (int i = 0; i < static_cast<int>(x.size()); ++i) {
-        x[i] = x_phys[i] * tpn.turb_scale_loc;
+        x[i] = file_coordinate(tpn, 0, x_phys[i] * tpn.turb_scale_loc);
       }
       for (int j = 0; j < static_cast<int>(y.size()); ++j) {
-        y[j] = y_phys[j] * tpn.turb_scale_loc;
+        y[j] = file_coordinate(tpn, 1, y_phys[j] * tpn.turb_scale_loc);
       }
 
       // Get the turbulence
@@ -364,6 +551,50 @@ TurbInflow::add_turb(
 
   // Moving it into data
   set_turb(dir, tdir1, tdir2, v, data, dcomp);
+}
+
+amrex::Real
+TurbInflow::file_coordinate(
+  const TurbParm& a_tp, int idim, amrex::Real x_file_phys)
+{
+  if (!a_tp.has_map) {
+    return x_file_phys;
+  }
+  const amrex::Real xi_lo = a_tp.map_xi_lo[idim];
+  const amrex::Real xi_hi = a_tp.map_xi_hi[idim];
+  const amrex::Real x_lo = a_tp.map.x_phys_from_xi(idim, xi_lo, xi_lo, xi_hi);
+  const amrex::Real x_hi = a_tp.map.x_phys_from_xi(idim, xi_hi, xi_lo, xi_hi);
+
+  amrex::Real x = x_file_phys;
+  if (a_tp.tile_periodic && a_tp.periodicity[idim] != 0) {
+    // Tiled: bring x into the file's physical period before inverting.
+    // The inverse clamps to [x_lo, x_hi], which would otherwise collapse
+    // every tiled copy onto the edge of the file.
+    const amrex::Real period = x_hi - x_lo;
+    x -= std::floor((x - x_lo) / period) * period;
+  } else if (x < x_lo || x >= x_hi) {
+    // Outside the file's physical extent.  A physically-uniform file leaves
+    // such positions unfilled (fill_turb_plane's range test); keep that
+    // behaviour rather than let the clamped inverse pin them to the edge
+    // row, by returning a Xi coordinate that is outside the box whatever
+    // turb_center shifted pboxlo to (|shift| <= pboxsize/2).
+    const amrex::Real away = a_tp.pboxsize[idim];
+    return (x < x_lo) ? xi_lo - away : xi_hi + away;
+  }
+
+  amrex::Real xi = a_tp.map.xi_from_x_phys(idim, x, xi_lo, xi_hi);
+
+  // When the target's map and Xi grid coincide with the file's, xi lands on
+  // a file cell centre up to the round-off of the inverse (log/atanh, or
+  // the Newton tolerance for InteriorStretch).  Snap it so that the
+  // interpolation weights collapse exactly and the same-map case
+  // reproduces the file bit for bit.
+  const amrex::Real idx = (xi - a_tp.pboxlo[idim]) * a_tp.dxinv[idim] + 0.5;
+  const amrex::Real idx_round = std::round(idx);
+  if (std::abs(idx - idx_round) < amrex::Real(1.0e-8)) {
+    xi = a_tp.pboxlo[idim] + (idx_round - 0.5) * a_tp.dx[idim];
+  }
+  return xi;
 }
 
 void

--- a/Support/TurbInflowGenerator/GNUmakefile
+++ b/Support/TurbInflowGenerator/GNUmakefile
@@ -22,7 +22,7 @@ Pdirs   := Base Boundary Extern/amrdata AmrCore
 Bpack   += $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 Blocs   += $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir))
 
-PPdirs  := Utility/PltFileManager
+PPdirs  := Utility/PltFileManager Utility/MeshMap
 Bpack   += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/Source/$(dir)/Make.package)
 Blocs   += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/Source/$(dir))
 

--- a/Support/TurbInflowGenerator/README.md
+++ b/Support/TurbInflowGenerator/README.md
@@ -6,6 +6,18 @@ It has three modes:
  - Generation from a periodic 3D plt file from a PeleLMeX simulation
 
 See the PelePhysics documentation for more details on using this tool in all modes.
+
+If the PeleLMeX run that produced the planes or the plt file used a mesh
+mapping (`geometry.mesh_mapping`), copy that run's mapping lines verbatim
+into this tool's input, e.g.
+
+    geometry.mesh_mapping = TanhStretchMap
+    TanhStretchMap.beta   = 2.0 0.0 0.0
+
+The generator then appends a `MESHMAP_V2` trailer to `HDR` recording the map
+and the precursor's computational-domain bounds, and TurbInflow samples the
+file in that coordinate.  Without the trailer a file is taken to be uniform
+in physical position, which is wrong for planes from a mapped run.
 The example below described how to use it for synthetic turbulence data.
 
 First generate the data using the python script:

--- a/Support/TurbInflowGenerator/Utilities.cpp
+++ b/Support/TurbInflowGenerator/Utilities.cpp
@@ -11,6 +11,51 @@ read_file(std::ifstream& in)
     .str();
 }
 
+void
+write_meshmap_trailer(
+  std::ofstream& ifsh, const RealBox& probDomain, const IntVect& dim_map)
+{
+  using pele::physics::MeshMapEvaluator;
+  const MeshMapEvaluator e =
+    pele::physics::make_evaluator_from_inputs(probDomain);
+  if (e.m_kind == MeshMapEvaluator::Kind::Identity) {
+    return;
+  }
+
+  // A stretched normal direction cannot be expressed in the file (the
+  // normal is time for diag_frame_planes, and a uniformly convected
+  // coordinate for periodic_plt).  Warn; it is the user's precursor.
+  const int dn = dim_map[2];
+  const bool normal_stretched =
+    (e.m_kind == MeshMapEvaluator::Kind::Constant)
+      ? (std::abs(e.m_p[dn] - Real(1.0)) > MeshMapEvaluator::BETA_EPS)
+      : (std::abs(e.m_p[dn]) > MeshMapEvaluator::BETA_EPS ||
+         std::abs(e.m_p2[dn]) > MeshMapEvaluator::BETA_EPS);
+  if (normal_stretched) {
+    amrex::Print()
+      << "WARNING: geometry.mesh_mapping stretches the file's normal "
+         "direction (plotfile axis "
+      << dn
+      << "); the turbulence file cannot represent that and TurbInflow "
+         "will treat the normal as uniform.\n";
+  }
+
+  const auto prec = ifsh.precision();
+  ifsh << std::setprecision(17);
+  ifsh << "MESHMAP_V2\n";
+  for (int t = 0; t < 2; ++t) {
+    const int d = dim_map[t];
+    ifsh << static_cast<int>(e.m_kind) << ' ' << e.m_p[d] << ' ' << e.m_p2[d]
+         << ' ' << e.m_p3[d] << ' ' << e.m_q[d] << ' ' << probDomain.lo(d)
+         << ' ' << probDomain.hi(d) << '\n';
+  }
+  ifsh << std::setprecision(prec);
+  amrex::Print() << "Wrote MESHMAP_V2 trailer (map kind "
+                 << static_cast<int>(e.m_kind)
+                 << "): the file is uniform in the precursor's Xi "
+                    "coordinate\n";
+}
+
 // Map from save domain (z-normal, x,y-tangential) to input domain (arbitrary)
 IntVect
 index_mapper(

--- a/Support/TurbInflowGenerator/diag_frame_planes.cpp
+++ b/Support/TurbInflowGenerator/diag_frame_planes.cpp
@@ -91,8 +91,10 @@ turbinflow_from_diag_frame_planes(std::ofstream& ifsd, std::ofstream& ifsh)
 
   dx[0] = planeSize[0] / bg[0];
   dx[1] = planeSize[1] / bg[1];
-  ifsh << planeSize[0] + 2 * dx[0] << ' ' << planeSize[1] + 2 * dx[1] << ' '
-       << nf << '\n';
+  // Full precision: TurbInflow derives the file's spacing from these, and
+  // for a mesh-mapped file they must agree with the trailer's Xi bounds.
+  ifsh << std::setprecision(17) << planeSize[0] + 2 * dx[0] << ' '
+       << planeSize[1] + 2 * dx[1] << ' ' << nf << '\n';
 
   ifsh << perio[0] << ' ' << perio[1] << ' ' << 0 << '\n';
 
@@ -139,6 +141,9 @@ turbinflow_from_diag_frame_planes(std::ofstream& ifsd, std::ofstream& ifsh)
   }
   // Write plane times
   for (int k = 0; k < nf; ++k) {
-    ifsh << fileTimes[k] << std::endl;
+    ifsh << std::setprecision(17) << fileTimes[k] << std::endl;
   }
+
+  // Optional mesh-mapping trailer; must come after the plane times.
+  write_meshmap_trailer(ifsh, probDomain, dim_map);
 }

--- a/Support/TurbInflowGenerator/main.H
+++ b/Support/TurbInflowGenerator/main.H
@@ -2,12 +2,14 @@
 #define _MAIN_H
 #include <string>
 #include <iostream>
+#include <iomanip>
 
 #include "AMReX_ParmParse.H"
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_FArrayBox.H>
 
 #include "PltFileManager.H"
+#include <MeshMapEvaluatorInputs.H>
 
 AMREX_ENUM(InputType, turb_box, diag_frame_planes, periodic_plt);
 
@@ -17,6 +19,20 @@ turbinflow_from_diag_frame_planes(std::ofstream& ifsd, std::ofstream& ifsh);
 void turbinflow_from_periodic_plt(std::ofstream& ifsd, std::ofstream& ifsh);
 
 void turbinflow_from_turb_box(std::ofstream& ifsd, std::ofstream& ifsh);
+
+/**
+ * Append the MESHMAP_V2 trailer to HDR when the inputs carry a
+ * geometry.mesh_mapping block (the precursor's, copied verbatim), so that
+ * the file is tagged as uniform in the precursor's computational (Xi)
+ * coordinate.  \p probDomain is the plotfile's (Xi-space) problem domain and
+ * \p dim_map the plotfile axes that become the file's transverse directions
+ * 0 and 1 and its normal 2.  Writes nothing without a mapping.  Must be the
+ * last thing written to HDR.
+ */
+void write_meshmap_trailer(
+  std::ofstream& ifsh,
+  const amrex::RealBox& probDomain,
+  const amrex::IntVect& dim_map);
 
 amrex::IntVect index_mapper(
   const amrex::IntVect& idx_in,

--- a/Support/TurbInflowGenerator/periodic_plt.cpp
+++ b/Support/TurbInflowGenerator/periodic_plt.cpp
@@ -95,8 +95,10 @@ turbinflow_from_periodic_plt(std::ofstream& ifsd, std::ofstream& ifsh)
   dx[0] = planeSize[0] / bg[0];
   dx[1] = planeSize[1] / bg[1];
   dx[2] = planeSize[2] / bg[2];
-  ifsh << planeSize[0] + 2 * dx[0] << ' ' << planeSize[1] + 2 * dx[1] << ' '
-       << planeSize[2] << '\n';
+  // Full precision: TurbInflow derives the file's spacing from these, and
+  // for a mesh-mapped file they must agree with the trailer's Xi bounds.
+  ifsh << std::setprecision(17) << planeSize[0] + 2 * dx[0] << ' '
+       << planeSize[1] + 2 * dx[1] << ' ' << planeSize[2] << '\n';
   ifsh << perio[dim_map[0]] << ' ' << perio[dim_map[1]] << ' ' << 1 << '\n';
 
   IntVect periodicity{perio[0], perio[1], perio[2]};
@@ -134,4 +136,8 @@ turbinflow_from_periodic_plt(std::ofstream& ifsd, std::ofstream& ifsh)
     }
     std::cout << "done" << std::endl;
   }
+
+  // Optional mesh-mapping trailer; must come after the plane offsets (this
+  // mode writes no plane times).
+  write_meshmap_trailer(ifsh, probDomain, dim_map);
 }


### PR DESCRIPTION
Follow-up to #692. That PR taught the `HDR` reader to recognise a trailer tagging a turbulence file as uniform in a precursor's computational (ξ) coordinate, but refused such files. This PR makes them usable end to end, and moves the mesh-mapping descriptor into PelePhysics so that the reader, the generators and PeleLMeX share one definition.

**The one rule**. A turbulence file is uniform in some coordinate: physical position for synthetic or uniform-precursor data, the precursor's ξ for planes extracted from a mesh-mapped run (`DiagFramePlane` and the plotfile writer both emit the ξ geometry with physical velocities). `add_turb()` now converts each target cell's physical transverse position into the file's own coordinate — the identity for a physical-uniform file, the inverse of the file's map for a mapped one — and everything downstream (`pboxlo`, `dx`, the affine index lookup, the interpolation weights, `fill_turb_plane`) is untouched. Interpolation in ξ is the standard mapped-grid argument: for a smooth map the interpolant's error is the same order in Δξ as it would be in Δx. Both directions of mismatch (uniform file → stretched target, stretched file → uniform or differently-stretched target) are covered by the same line, and the same-map case reproduces the file exactly.

**Commits.**

1. `MeshMap: add MeshMapEvaluator` — `Source/Utility/MeshMap/MeshMapEvaluator.H`, PeleLMeX's device-callable POD descriptor (Constant / ExpStretch / TanhStretch / InteriorStretch, forward and inverse primitives) in `namespace` `pele::physics`, plus (`plo, phi`) overloads for callers with no `amrex::Geometry`. `MeshMapEvaluatorInputs.H` adds a host-only `make_evaluator_from_inputs()` reading the same ParmParse block PeleLMeX's map classes read, with the same defaults and validation. PeleLMeX will reduce its header to an alias.
2. `TurbInflow: sample mesh-mapped files by inverting their map` — the trailer is now `MESHMAP_V2` (kind `p p2 p3 q xi_lo xi_hi` per transverse direction, the full evaluator payload so InteriorStretch is representable; V1 is still read with `p2 = p3 = 0`). `TurbParm` holds a `MeshMapEvaluator` and the file's ξ bounds. `tile_periodic` wraps into the file's physical period before the inverse; positions outside a non-tiled file stay unfilled as before; the inverse is snapped to a file cell centre when within 1e-8 of one so the same-map case collapses the weights. `turb_center` becomes optional for mapped files (default: where the precursor had it; if given, in the file's ξ units, checked against `[xi_lo, xi_hi]`, physical equivalent printed). `file_transverse_dx()` reports the mean physical spacing for mapped files; new `file_transverse_dx_range()` and `file_map()` let a solver report min/max spacing and whether its own map matches. The ξ spacing of a mapped file is derived from the trailer (exact) after checking it against the header's `probsize`.
3. `TurbInflowGenerator: write the MESHMAP_V2 trailer` — `diag_frame_planes` and `periodic_plt` append the trailer when their input carries the precursor's `geometry.mesh_mapping` block (copied verbatim), with `xi_lo/xi_hi` from the plotfile probDomain along the axes that become the file's transverse directions; nothing is written without a mapping. Header probsize and plane times are written at full precision. A map stretching the file's normal direction is warned about.
4. Docs + `PELEPHYSICS_TURBINFLOW_SAMPLES_MESHMAP` feature macro.

`turbinflow.H` includes the evaluator by a path relative to itself, so builds that list `TurbInflow` but not `MeshMap` among their include directories (CMake consumers) keep compiling. GNU-make consumers get the include dir from `TurbInflow/Make.package`.

**Checks** (serial gnu driver, Linux). Identity regression: an existing (trailer-less) file sampled on a uniform target and on a tanh-mapped target reproduces the #692 code bit for bit. Same-map round trip: a tanh-mapped PeleLMeX `DiagFramePlane` series → `diag_frame_planes` (trailer written) → sampled on the same tanh mesh at a plane time reproduces the plane to 3e-17. Cross-map: the same file sampled on a uniform target matches an independent numpy linear-in-ξ interpolation of the plane to 1e-15; a tanh-tagged synthetic file on a finer uniform target and tiled over a wider one agree to 1e-14 with a reference that pre-inverts the coordinates by hand. A V1 trailer gives the same result as V2.

The PeleLMeX side (alias header, map-match report replacing the setup NOTE, round-trip and cross-map regression inputs in `Exec/RegTests/TurbInflow`) follows in a PeleLMeX PR once this merges.